### PR TITLE
Implements `multus.is_ready()` that validates if pod is running with expected annotations

### DIFF
--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -131,6 +131,7 @@ class KubernetesClient:
     def pod_is_ready(
         self,
         pod_name: str,
+        *,
         network_annotations: list[NetworkAnnotation],
         containers_requiring_net_admin_capability: list[str],
     ) -> bool:

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -76,6 +76,7 @@ from lightkube.models.core_v1 import (
 )
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.apps_v1 import StatefulSet
+from lightkube.resources.core_v1 import Pod
 from lightkube.types import PatchType
 from ops.charm import CharmBase, EventBase, RemoveEvent
 from ops.framework import Object
@@ -88,7 +89,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 logger = logging.getLogger(__name__)
@@ -126,6 +127,44 @@ class KubernetesClient:
     def __init__(self, namespace: str):
         self.client = Client()
         self.namespace = namespace
+
+    def pod_is_ready(
+        self,
+        pod_name: str,
+        network_annotations: list[NetworkAnnotation],
+        containers_requiring_net_admin_capability: list[str],
+    ) -> bool:
+        """Returns whether pod has the requisite network annotation and NET_ADMIN capability.
+
+        Args:
+            pod_name: Pod name
+            network_annotations: List of network annotations
+            containers_requiring_net_admin_capability: List of containers requiring NET_ADMIN
+                capability
+
+        Returns:
+            bool: Whether pod is ready.
+        """
+        try:
+            pod = self.client.get(Pod, name=pod_name, namespace=self.namespace)
+        except ApiError:
+            raise KubernetesMultusError(f"Pod {pod_name} not found")
+        if "k8s.v1.cni.cncf.io/networks" not in pod.metadata.annotations:
+            return False
+        try:
+            if json.loads(pod.metadata.annotations["k8s.v1.cni.cncf.io/networks"]) != [
+                network_annotation.dict() for network_annotation in network_annotations
+            ]:
+                logger.info("Existing annotation are not identical to the expected ones")
+                return False
+        except JSONDecodeError:
+            logger.info("Existing annotations are not a valid json.")
+            return False
+        for container in pod.spec.containers:
+            if container.name in containers_requiring_net_admin_capability:
+                if "NET_ADMIN" not in container.securityContext.capabilities.add:
+                    return False
+        return True
 
     def network_attachment_definition_is_created(self, name: str) -> bool:
         """Returns whether a NetworkAttachmentDefinition is created.
@@ -349,37 +388,52 @@ class KubernetesMultusCharmLib(Object):
                 self.kubernetes.create_network_attachment_definition(
                     network_attachment_definition=network_attachment_definition
                 )
-        network_annotations = self.network_annotations_func()
-        if not self.kubernetes.statefulset_is_patched(
-            name=self.model.app.name,
-            network_annotations=network_annotations,
-            containers_requiring_net_admin_capability=self.containers_requiring_net_admin_capability,  # noqa: E501
-        ):
+        if not self._statefulset_is_patched():
             self.kubernetes.patch_statefulset(
                 name=self.model.app.name,
-                network_annotations=network_annotations,
+                network_annotations=self.network_annotations_func(),
                 containers_requiring_net_admin_capability=self.containers_requiring_net_admin_capability,  # noqa: E501
             )
 
-    def multus_is_configured(self) -> bool:
-        """Returns whether multus is configured.
-
-        Returns:
-            bool: Whether multus is configured
-        """
+    def _network_attachment_definitions_are_created(self):
         for network_attachment_definition in self.network_attachment_definitions:
             if not self.kubernetes.network_attachment_definition_is_created(
                 name=network_attachment_definition.metadata.name  # type: ignore[union-attr]
             ):
                 return False
-        network_annotations = self.network_annotations_func()
-        if not self.kubernetes.statefulset_is_patched(
-            name=self.model.app.name,
-            network_annotations=network_annotations,
-            containers_requiring_net_admin_capability=self.containers_requiring_net_admin_capability,  # noqa: E501
-        ):
-            return False
         return True
+
+    def _statefulset_is_patched(self) -> bool:
+        return self.kubernetes.statefulset_is_patched(
+            name=self.model.app.name,
+            network_annotations=self.network_annotations_func(),
+            containers_requiring_net_admin_capability=self.containers_requiring_net_admin_capability,  # noqa: E501
+        )
+
+    def _pod_is_ready(self) -> bool:
+        """Returns whether pod is ready."""
+        return self.kubernetes.pod_is_ready(
+            containers_requiring_net_admin_capability=self.containers_requiring_net_admin_capability,  # noqa: E501
+            pod_name=self._pod,
+            network_annotations=self.network_annotations_func(),
+        )
+
+    def is_ready(self) -> bool:
+        """Returns whether Multus is ready."""
+        return (
+            self._network_attachment_definitions_are_created()
+            and self._statefulset_is_patched()  # noqa: W503
+            and self._pod_is_ready()  # noqa: W503
+        )
+
+    @property
+    def _pod(self) -> str:
+        """Name of the unit's pod.
+
+        Returns:
+            str: A string containing the name of the current unit's pod.
+        """
+        return "-".join(self.model.unit.name.rsplit("/", 1))
 
     def _on_remove(self, event: RemoveEvent) -> None:
         """Deletes network attachment definitions.

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -149,10 +149,10 @@ class KubernetesClient:
             pod = self.client.get(Pod, name=pod_name, namespace=self.namespace)
         except ApiError:
             raise KubernetesMultusError(f"Pod {pod_name} not found")
-        if "k8s.v1.cni.cncf.io/networks" not in pod.metadata.annotations:
+        if "k8s.v1.cni.cncf.io/networks" not in pod.metadata.annotations:  # type: ignore[attr-defined]  # noqa: E501
             return False
         try:
-            if json.loads(pod.metadata.annotations["k8s.v1.cni.cncf.io/networks"]) != [
+            if json.loads(pod.metadata.annotations["k8s.v1.cni.cncf.io/networks"]) != [  # type: ignore[attr-defined]  # noqa: E501
                 network_annotation.dict() for network_annotation in network_annotations
             ]:
                 logger.info("Existing annotation are not identical to the expected ones")
@@ -160,7 +160,7 @@ class KubernetesClient:
         except JSONDecodeError:
             logger.info("Existing annotations are not a valid json.")
             return False
-        for container in pod.spec.containers:
+        for container in pod.spec.containers:  # type: ignore[attr-defined]
             if container.name in containers_requiring_net_admin_capability:
                 if "NET_ADMIN" not in container.securityContext.capabilities.add:
                     return False

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -395,7 +395,8 @@ class KubernetesMultusCharmLib(Object):
                 containers_requiring_net_admin_capability=self.containers_requiring_net_admin_capability,  # noqa: E501
             )
 
-    def _network_attachment_definitions_are_created(self):
+    def _network_attachment_definitions_are_created(self) -> bool:
+        """Returns whether all network attachment definitions are created."""
         for network_attachment_definition in self.network_attachment_definitions:
             if not self.kubernetes.network_attachment_definition_is_created(
                 name=network_attachment_definition.metadata.name  # type: ignore[union-attr]
@@ -404,6 +405,7 @@ class KubernetesMultusCharmLib(Object):
         return True
 
     def _statefulset_is_patched(self) -> bool:
+        """Returns whether statefuset is patched with network annotations and capabilities."""
         return self.kubernetes.statefulset_is_patched(
             name=self.model.app.name,
             network_annotations=self.network_annotations_func(),
@@ -411,7 +413,7 @@ class KubernetesMultusCharmLib(Object):
         )
 
     def _pod_is_ready(self) -> bool:
-        """Returns whether pod is ready."""
+        """Returns whether pod is ready with network annotations and capabilities."""
         return self.kubernetes.pod_is_ready(
             containers_requiring_net_admin_capability=self.containers_requiring_net_admin_capability,  # noqa: E501
             pod_name=self._pod,
@@ -419,7 +421,15 @@ class KubernetesMultusCharmLib(Object):
         )
 
     def is_ready(self) -> bool:
-        """Returns whether Multus is ready."""
+        """Returns whether Multus is ready.
+
+        Validates that the network attachment definitions are created, that the statefulset is
+        patched with the appropriate Multus annotations and capabilities and that the pod
+        also contains the same annotations and capabilities.
+
+        Returns:
+            bool: Whether Multus is ready
+        """
         return (
             self._network_attachment_definitions_are_created()
             and self._statefulset_is_patched()  # noqa: W503

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -698,7 +698,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         harness.begin()
 
         is_ready = harness.charm.kubernetes_multus.is_ready()
-        self.assertEqual(False, is_ready)
+        self.assertFalse(is_ready)
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.pod_is_ready")

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -719,4 +719,4 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         harness.begin()
 
         is_ready = harness.charm.kubernetes_multus.is_ready()
-        self.assertEqual(True, is_ready)
+        self.assertTrue(is_ready)

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -467,7 +467,7 @@ class TestKubernetes(unittest.TestCase):
             containers_requiring_net_admin_capability=[container_name],
         )
 
-        self.assertEqual(True, is_ready)
+        self.assertTrue(is_ready)
 
 
 class _TestCharmNoNAD(CharmBase):

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -381,7 +381,7 @@ class TestKubernetes(unittest.TestCase):
             containers_requiring_net_admin_capability=[],
         )
 
-        self.assertEqual(False, is_ready)
+        self.assertFalse(is_ready)
 
     @patch("lightkube.core.client.Client.get")
     def test_given_annotation_badly_set_when_pod_is_ready_then_returns_false(self, patch_get):

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -435,7 +435,7 @@ class TestKubernetes(unittest.TestCase):
             containers_requiring_net_admin_capability=[container_name],
         )
 
-        self.assertEqual(False, is_ready)
+        self.assertFalse(is_ready)
 
     @patch("lightkube.core.client.Client.get")
     def test_given_pod_is_ready_when_pod_is_ready_then_returns_true(self, patch_get):

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -679,6 +679,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
 
         patch_delete_network_attachment_definition.assert_not_called()
 
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.pod_is_ready")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.network_attachment_definition_is_created")
@@ -699,6 +700,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         is_ready = harness.charm.kubernetes_multus.is_ready()
         self.assertEqual(False, is_ready)
 
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.pod_is_ready")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.network_attachment_definition_is_created")

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -405,7 +405,7 @@ class TestKubernetes(unittest.TestCase):
             containers_requiring_net_admin_capability=[],
         )
 
-        self.assertEqual(False, is_ready)
+        self.assertFalse(is_ready)
 
     @patch("lightkube.core.client.Client.get")
     def test_given_net_admin_not_set_when_pod_is_ready_then_returns_false(self, patch_get):


### PR DESCRIPTION
# Description

Replaces `multus.is_configured()` with `multus.is_ready()` that validates if pod is running with expected annotations.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
