### PR TITLE
(Fix) Adding handling for ApiError 401 Unauthorized

### DIFF
--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -102,7 +102,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 logger = logging.getLogger(__name__)
@@ -178,8 +178,10 @@ class KubernetesClient:
         """
         try:
             pod = self.client.get(Pod, name=pod_name, namespace=self.namespace)
-        except ApiError:
-            raise KubernetesMultusError(f"Pod {pod_name} not found")
+        except ApiError as e:
+            if e.status.reason != "Unauthorized":
+                raise KubernetesMultusError(f"Pod {pod_name} not found")
+            return False
         return self._pod_is_patched(
             pod=pod,  # type: ignore[arg-type]
             network_annotations=network_annotations,
@@ -207,7 +209,7 @@ class KubernetesClient:
             )
             return existing_nad == network_attachment_definition
         except ApiError as e:
-            if e.status.reason != "NotFound":
+            if e.status.reason not in ["NotFound", "Unauthorized"]:
                 raise KubernetesMultusError(
                     f"Unexpected outcome when retrieving NetworkAttachmentDefinition "
                     f"{network_attachment_definition.metadata.name}"
@@ -360,8 +362,10 @@ class KubernetesClient:
         """
         try:
             statefulset = self.client.get(res=StatefulSet, name=name, namespace=self.namespace)
-        except ApiError:
-            raise KubernetesMultusError(f"Could not get statefulset {name}")
+        except ApiError as e:
+            if e.status.reason != "Unauthorized":
+                raise KubernetesMultusError(f"Could not get statefulset {name}")
+            return False
         return self._pod_is_patched(
             container_name=container_name,
             cap_net_admin=cap_net_admin,


### PR DESCRIPTION
# Description

Problem found while testing SD-Core on a low-spec hardware. 
This PR adds handling for a situation in which `kube-apiserver` is to yet ready when requested for information. Before this change, code would simply raise an exception, not giving `kube-apiserver` a chance.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
