### PR TITLE
Add delete pod and list NADs methods for NADs reconfiguration

### DIFF
--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -102,7 +102,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 logger = logging.getLogger(__name__)
@@ -147,6 +147,15 @@ class KubernetesClient:
     def __init__(self, namespace: str):
         self.client = Client()
         self.namespace = namespace
+
+    def delete_pod(self, pod_name: str) -> None:
+        """Deleting given pod.
+
+        Args:
+            pod_name    (str): Pod name to delete
+
+        """
+        self.client.delete(Pod, pod_name, namespace=self.namespace)
 
     def pod_is_ready(
         self,
@@ -547,7 +556,6 @@ class KubernetesMultusCharmLib(Object):
                     network_attachment_definitions_to_create.remove(
                         existing_network_attachment_definition
                     )
-
         for network_attachment_definition_to_create in network_attachment_definitions_to_create:
             self.kubernetes.create_network_attachment_definition(
                 network_attachment_definition=network_attachment_definition_to_create
@@ -619,3 +627,15 @@ class KubernetesMultusCharmLib(Object):
                 self.kubernetes.delete_network_attachment_definition(
                     name=network_attachment_definition.metadata.name  # type: ignore[union-attr]
                 )
+
+    def delete_pod(self) -> None:
+        """Delete the pod."""
+        self.kubernetes.delete_pod(self._pod)
+
+    def get_nad_definitions(self) -> list[NetworkAttachmentDefinition]:
+        """Get all existing network attachment definitions in the namespace.
+
+        Returns:
+            NetworkAttachmentDefinitions    (list) :    List of network attachment definitions
+        """
+        return self.kubernetes.list_network_attachment_definitions()

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -152,7 +152,7 @@ class KubernetesClient:
         """Deleting given pod.
 
         Args:
-            pod_name (str): Pod name to delete
+            pod_name (str): Pod name
 
         """
         self.client.delete(Pod, pod_name, namespace=self.namespace)

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -152,7 +152,7 @@ class KubernetesClient:
         """Deleting given pod.
 
         Args:
-            pod_name    (str): Pod name to delete
+            pod_name (str): Pod name to delete
 
         """
         self.client.delete(Pod, pod_name, namespace=self.namespace)
@@ -636,6 +636,6 @@ class KubernetesMultusCharmLib(Object):
         """Get all existing network attachment definitions in the namespace.
 
         Returns:
-            NetworkAttachmentDefinitions    (list) :    List of network attachment definitions
+            NetworkAttachmentDefinitions (list) : List of network attachment definitions
         """
         return self.kubernetes.list_network_attachment_definitions()

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -632,7 +632,7 @@ class KubernetesMultusCharmLib(Object):
         """Delete the pod."""
         self.kubernetes.delete_pod(self._pod)
 
-    def get_nad_definitions(self) -> list[NetworkAttachmentDefinition]:
+    def get_network_attachment_definitions(self) -> list[NetworkAttachmentDefinition]:
         """Get all existing network attachment definitions in the namespace.
 
         Returns:

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -601,7 +601,9 @@ class TestKubernetes(unittest.TestCase):
             self.kubernetes_multus.list_network_attachment_definitions()
 
     @patch("lightkube.core.client.Client.delete")
-    def test_given_pod_is_deleted_then_k8s_delete_is_called(self, patch_delete):
+    def test_given_pod_is_deleted_when_delete_pod_then_client_delete_is_called_by_pod_name_and_namespace(  # noqa: E501
+        self, patch_delete
+    ):
         pod_name = "whatever pod"
 
         self.kubernetes_multus.delete_pod(pod_name)
@@ -1019,7 +1021,9 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_pod")
-    def test_given_pod_is_deleted_then_k8s_delete_is_called(self, patch_delete):
+    def test_given_pod_is_deleted_when_multus_delete_pod_then_k8s_client_delete_pod_is_called(
+        self, patch_delete
+    ):  # noqa: E501
         harness = Harness(_TestCharmNoNAD)
         self.addCleanup(harness.cleanup)
         harness.begin()

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -1028,7 +1028,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
-    def test_given_k8s_returns_list_when_get_nad_definitions_then_same_list_is_returned(  # noqa: E501
+    def test_given_k8s_returns_list_when_get_network_attachment_definitions_then_same_list_is_returned(  # noqa: E501
         self, patch_list
     ):
         harness = Harness(_TestCharmNoNAD)
@@ -1036,17 +1036,17 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         harness.begin()
         nad_list_return = ["whatever", "list", "content"]
         patch_list.return_value = nad_list_return
-        expected_nad_list = harness.charm.kubernetes_multus.get_nad_definitions()
+        expected_nad_list = harness.charm.kubernetes_multus.get_network_attachment_definitions()
         self.assertListEqual(nad_list_return, expected_nad_list)
         patch_list.assert_called_once()
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
-    def test_given_k8s_returns_list_when_get_nad_definitions_then_list_network_attachment_definitions_is_called(  # noqa: E501
+    def test_given_k8s_returns_list_when_get_network_attachment_definitions_then_list_network_attachment_definitions_is_called(  # noqa: E501
         self, patch_list
     ):
         harness = Harness(_TestCharmNoNAD)
         self.addCleanup(harness.cleanup)
         harness.begin()
-        harness.charm.kubernetes_multus.get_nad_definitions()
+        harness.charm.kubernetes_multus.get_network_attachment_definitions()
         patch_list.assert_called_once()

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -19,13 +19,13 @@ from lightkube.models.apps_v1 import StatefulSet, StatefulSetSpec
 from lightkube.models.core_v1 import (
     Capabilities,
     Container,
-    Pod,
     PodSpec,
     PodTemplateSpec,
     SecurityContext,
 )
 from lightkube.models.meta_v1 import LabelSelector, ObjectMeta
 from lightkube.resources.apps_v1 import StatefulSet as StatefulSetResource
+from lightkube.resources.core_v1 import Pod
 from lightkube.types import PatchType
 from ops.charm import CharmBase
 from ops.testing import Harness
@@ -600,6 +600,14 @@ class TestKubernetes(unittest.TestCase):
         with pytest.raises(KubernetesMultusError):
             self.kubernetes_multus.list_network_attachment_definitions()
 
+    @patch("lightkube.core.client.Client.delete")
+    def test_given_pod_is_deleted_then_k8s_delete_is_called(self, patch_delete):
+        pod_name = "whatever pod"
+
+        self.kubernetes_multus.delete_pod(pod_name)
+
+        patch_delete.assert_called_with(Pod, pod_name, namespace=self.namespace)
+
 
 class _TestCharmNoNAD(CharmBase):
     def __init__(self, *args):
@@ -1008,3 +1016,37 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
 
         is_ready = harness.charm.kubernetes_multus.is_ready()
         self.assertTrue(is_ready)
+
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_pod")
+    def test_given_pod_is_deleted_then_k8s_delete_is_called(self, patch_delete):
+        harness = Harness(_TestCharmNoNAD)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.kubernetes_multus.delete_pod()
+        patch_delete.assert_called_once()
+
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    def test_given_k8s_returns_list_when_get_nad_definitions_then_same_list_is_returned(  # noqa: E501
+        self, patch_list
+    ):
+        harness = Harness(_TestCharmNoNAD)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        nad_list_return = ["whatever", "list", "content"]
+        patch_list.return_value = nad_list_return
+        expected_nad_list = harness.charm.kubernetes_multus.get_nad_definitions()
+        self.assertListEqual(nad_list_return, expected_nad_list)
+        patch_list.assert_called_once()
+
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    def test_given_k8s_returns_list_when_get_nad_definitions_then_list_network_attachment_definitions_is_called(  # noqa: E501
+        self, patch_list
+    ):
+        harness = Harness(_TestCharmNoNAD)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.kubernetes_multus.get_nad_definitions()
+        patch_list.assert_called_once()


### PR DESCRIPTION
# Description

For NAD reconfiguration, additional methods delete_pod and list_network_attachment_definitions are required. Those methods are added to library with unit tests.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
