### PR TITLE
Trigger pod restart when NAD config changed

### DIFF
--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -115,13 +115,8 @@ from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import Pod
 from lightkube.types import PatchType
-<<<<<<< HEAD
 from ops.charm import CharmBase, RemoveEvent
 from ops.framework import BoundEvent, Object
-=======
-from ops.charm import CharmBase, CharmEvents, EventBase, EventSource, RemoveEvent
-from ops.framework import Handle, Object
->>>>>>> 9f64d64 (Add NAD config change event and trigger pod restart)
 
 # The unique Charmhub library identifier, never change it
 LIBID = "75283550e3474e7b8b5b7724d345e3c2"
@@ -131,7 +126,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)
@@ -168,19 +163,6 @@ class KubernetesMultusError(Exception):
     def __init__(self, message: str):
         self.message = message
         super().__init__(self.message)
-
-
-class NadConfigChangedEvent(EventBase):
-    """Event triggered when an existing network attachment definition is changed."""
-
-    def __init__(self, handle: Handle):
-        super().__init__(handle)
-
-
-class NadConfigChangedCharmEvents(CharmEvents):
-    """NAD config changed events."""
-
-    nad_config_changed = EventSource(NadConfigChangedEvent)
 
 
 class KubernetesClient:
@@ -511,8 +493,6 @@ class KubernetesClient:
 class KubernetesMultusCharmLib(Object):
     """Class to be instantiated by charms requiring Multus networking."""
 
-    on = NadConfigChangedCharmEvents()
-
     def __init__(
         self,
         charm: CharmBase,
@@ -546,12 +526,6 @@ class KubernetesMultusCharmLib(Object):
         # Apply custom events
         self.framework.observe(refresh_event, self._configure_multus)
         self.framework.observe(charm.on.remove, self._on_remove)
-        self.framework.observe(self.on.nad_config_changed, self._on_nad_config_changed)
-
-    def _on_nad_config_changed(self, event: NadConfigChangedEvent) -> None:
-        """Deletes the pod."""
-        self.delete_pod()
-        logger.info("Pod is restarted to make the new NAD configs effective.")
 
     def _configure_multus(self, event: BoundEvent) -> None:
         """Creates network attachment definitions and patches statefulset.
@@ -591,14 +565,10 @@ class KubernetesMultusCharmLib(Object):
             list of NetworkAttachmentDefinitions to create
           - Else, delete it
         2. Goes through the list of NetworkAttachmentDefinitions to create and create them all
-        3. Detects the NAD config changes and emits the NadConfigChangedEvent once
+        3. Detects the NAD config changes and triggers pod restart
            if any there is any modification in existing NADs
         """
         network_attachment_definitions_to_create = self.network_attachment_definitions_func()
-        if network_attachment_definitions_to_create is None:
-            # If the NAD configs are not valid, this is set to None
-            # by charm to exit without processing as a protection.
-            return
         nad_config_changed = False
         for (
             existing_network_attachment_definition
@@ -625,7 +595,8 @@ class KubernetesMultusCharmLib(Object):
         if nad_config_changed:
             # We want to trigger the pod restart once if there is a change in NADs
             # after all the NADs are configured.
-            self.on.nad_config_changed.emit()
+            logger.warning("Restarting pod to make the new NAD configs effective.")
+            self.delete_pod()
 
     def _network_attachment_definitions_are_created(self) -> bool:
         """Returns whether all network attachment definitions are created."""
@@ -697,11 +668,3 @@ class KubernetesMultusCharmLib(Object):
     def delete_pod(self) -> None:
         """Delete the pod."""
         self.kubernetes.delete_pod(self._pod)
-
-    def get_network_attachment_definitions(self) -> list[NetworkAttachmentDefinition]:
-        """Get all existing network attachment definitions in the namespace.
-
-        Returns:
-            NetworkAttachmentDefinitions (list) : List of network attachment definitions
-        """
-        return self.kubernetes.list_network_attachment_definitions()

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -24,9 +24,6 @@ from charms.kubernetes_charm_libraries.v0.multus import (
 
 class NadConfigChangedEvent(EventBase):
 
-    def __init__(self, handle: Handle):
-        super().__init__(handle)
-
 
 class KubernetesMultusCharmEvents(CharmEvents):
 

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -612,7 +612,6 @@ class TestKubernetes(unittest.TestCase):
         patch_delete.assert_called_with(Pod, pod_name, namespace=self.namespace)
 
 
-<<<<<<< HEAD
 class NadConfigChangedEvent(EventBase):
     """Event triggered when an existing network attachment definition is changed."""
 
@@ -624,26 +623,6 @@ class KubernetesMultusCharmEvents(CharmEvents):
     """Kubernetes Multus Charm Events."""
 
     nad_config_changed = EventSource(NadConfigChangedEvent)
-=======
-class _TestCharmInvalidNAD(CharmBase):
-    """If invalid config is provided by user, _network_annotations_func returns None.
-
-    This is the protection mechanism not to process invalid configs.
-    """
-
-    def __init__(self, *args):
-        super().__init__(*args)
-        self.network_annotations = []
-        self.kubernetes_multus = KubernetesMultusCharmLib(
-            charm=self,
-            network_attachment_definitions_func=self._network_annotations_func,
-            network_annotations=self.network_annotations,
-            container_name="container-name",
-        )
-
-    def _network_annotations_func(self) -> list[NetworkAttachmentDefinition]:
-        return None  # type: ignore
->>>>>>> 9f64d64 (Add NAD config change event and trigger pod restart)
 
 
 class _TestCharmNoNAD(CharmBase):
@@ -738,28 +717,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
-<<<<<<< HEAD
     def test_given_nads_already_exist_when_nad_config_changed_then_create_is_not_called(
-=======
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition")
-    def test_given_invalid_nads_to_create_when_config_changed_then_does_nothing(  # noqa: E501
-        self, patch_delete_nad, patch_create_nad, patch_list_nads
-    ):
-        harness = Harness(_TestCharmInvalidNAD)
-        self.addCleanup(harness.cleanup)
-        harness.begin()
-        harness.charm.on.config_changed.emit()
-        patch_create_nad.assert_not_called()
-        patch_delete_nad.assert_not_called()
-        patch_list_nads.assert_not_called()
-
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
-    def test_given_nads_already_exist_when_config_changed_then_create_is_not_called(
->>>>>>> 9f64d64 (Add NAD config change event and trigger pod restart)
         self,
         patch_create_nad,
         patch_list_nads,
@@ -885,14 +843,12 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         )
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_pod")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(
         f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
     )
-<<<<<<< HEAD
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition")
     def test_given_nads_exist_but_are_different_when_nad_config_changed_then_nad_delete_is_called(
         self, patch_delete_nad, patch_list_nads
@@ -936,13 +892,80 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition")
     def test_given_nads_exist_but_are_different_when_config_changed_then_nad_delete_is_not_called(
         self, patch_delete_nad, patch_list_nads
-=======
+    ):
+        harness = Harness(_TestCharmMultipleNAD)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        patch_list_nads.return_value = [
+            NetworkAttachmentDefinition(
+                metadata=ObjectMeta(
+                    name=harness.charm.nad_1_name,
+                    labels={"app.juju.is/created-by": harness.charm.app.name},
+                ),
+                spec={"different": "spec"},
+            ),
+            NetworkAttachmentDefinition(
+                metadata=ObjectMeta(
+                    name=harness.charm.nad_2_name,
+                    labels={"app.juju.is/created-by": harness.charm.app.name},
+                ),
+                spec={"different": "spec"},
+            ),
+        ]
+
+        harness.charm.on.config_changed.emit()
+
+        patch_delete_nad.assert_not_called()
+
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_pod")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
+    )
     @patch(
         f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition", new=Mock
     )
-    def test_given_nads_exist_but_they_are_different_when_config_changed_then_pod_delete_is_called_once(  # noqa: E501
+    def test_given_nads_exist_but_they_are_different_when_nad_config_changed_then_pod_delete_is_called_once(  # noqa: E501
         self, patch_list_nads, patch_delete_pod
->>>>>>> 9f64d64 (Add NAD config change event and trigger pod restart)
+    ):
+        harness = Harness(_TestCharmMultipleNAD)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        patch_list_nads.return_value = [
+            NetworkAttachmentDefinition(
+                metadata=ObjectMeta(
+                    name=harness.charm.nad_1_name,
+                    labels={"app.juju.is/created-by": harness.charm.app.name},
+                ),
+                spec={"different": "spec"},
+            ),
+            NetworkAttachmentDefinition(
+                metadata=ObjectMeta(
+                    name=harness.charm.nad_2_name,
+                    labels={"app.juju.is/created-by": harness.charm.app.name},
+                ),
+                spec={"different": "spec"},
+            ),
+        ]
+        harness.charm.on.nad_config_changed.emit()
+        patch_delete_pod.assert_called_once()
+
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_pod")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
+    )
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition", new=Mock
+    )
+    def test_given_nads_exist_but_they_are_different_when_config_changed_then_pod_delete_is_not_called(  # noqa: E501
+        self, patch_list_nads, patch_delete_pod
     ):
         harness = Harness(_TestCharmMultipleNAD)
         self.addCleanup(harness.cleanup)
@@ -964,11 +987,8 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
             ),
         ]
         harness.charm.on.config_changed.emit()
-        patch_delete_pod.assert_called_once()
+        patch_delete_pod.assert_not_called()
 
-<<<<<<< HEAD
-        patch_delete_nad.assert_not_called()
-=======
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_pod")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
@@ -980,7 +1000,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
     @patch(
         f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition", new=Mock
     )
-    def test_given_nads_exist_but_are_same_when_config_changed_then_pod_delete_is_not_called(
+    def test_given_nads_exist_but_are_same_when_nad_config_changed_then_pod_delete_is_not_called(
         self, patch_list_nads, patch_delete_pod
     ):
         harness = Harness(_TestCharmMultipleNAD)
@@ -1010,20 +1030,15 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
                 },
             ),
         ]
-        harness.charm.on.config_changed.emit()
+        harness.charm.on.nad_config_changed.emit()
         patch_delete_pod.assert_not_called()
->>>>>>> 9f64d64 (Add NAD config change event and trigger pod restart)
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
-<<<<<<< HEAD
     def test_given_nads_exist_but_are_different_when_nad_config_changed_then_nad_create_is_called(
-=======
-    def test_given_nads_exist_but_are_different_when_config_changed_then_nad_create_is_called(
->>>>>>> 9f64d64 (Add NAD config change event and trigger pod restart)
         self, patch_create_nad, patch_list_nads
     ):
         harness = Harness(_TestCharmMultipleNAD)
@@ -1202,28 +1217,3 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         harness.begin()
         harness.charm.kubernetes_multus.delete_pod()
         patch_delete.assert_called_once()
-
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
-    def test_given_k8s_returns_list_when_get_network_attachment_definitions_then_same_list_is_returned(  # noqa: E501
-        self, patch_list
-    ):
-        harness = Harness(_TestCharmNoNAD)
-        self.addCleanup(harness.cleanup)
-        harness.begin()
-        nad_list_return = ["whatever", "list", "content"]
-        patch_list.return_value = nad_list_return
-        expected_nad_list = harness.charm.kubernetes_multus.get_network_attachment_definitions()
-        self.assertListEqual(nad_list_return, expected_nad_list)
-        patch_list.assert_called_once()
-
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
-    def test_given_k8s_returns_list_when_get_network_attachment_definitions_then_list_network_attachment_definitions_is_called(  # noqa: E501
-        self, patch_list
-    ):
-        harness = Harness(_TestCharmNoNAD)
-        self.addCleanup(harness.cleanup)
-        harness.begin()
-        harness.charm.kubernetes_multus.get_network_attachment_definitions()
-        patch_list.assert_called_once()


### PR DESCRIPTION
# Description

This PR aims to detect the modification in the existing NADs and triggers pod restart after new NADs are created
Besides, it also implements a protection not to change NADs if invalid config is provided by user.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
