### PR TITLE
Use custom event to trigger NAD configuration

### DIFF
--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -3,7 +3,8 @@
 
 """Charm Library used to leverage the Multus Kubernetes CNI in charms.
 
-- On a Bound event (e.g. NadConfigChangedEvent), it will:
+- On a BoundEvent (e.g. self.on.nad_config_changed which is originated from NadConfigChangedEvent),
+ it will:
   - Configure the requested network attachment definitions
   - Patch the statefulset with the necessary annotations for the container to have interfaces
     that use those new network attachments.
@@ -17,13 +18,13 @@
 from charms.kubernetes_charm_libraries.v0.multus import (
     KubernetesMultusCharmLib,
     NetworkAttachmentDefinition,
-    NadConfigChangedCharmEvents,
+    KubernetesMultusCharmEvents,
     NetworkAnnotation,
 )
 
 class YourCharm(CharmBase):
 
-    on = NadConfigChangedCharmEvents()
+    on = KubernetesMultusCharmEvents()
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -485,8 +486,8 @@ class NadConfigChangedEvent(EventBase):
         super().__init__(handle)
 
 
-class NadConfigChangedCharmEvents(CharmEvents):
-    """NAD config changed events."""
+class KubernetesMultusCharmEvents(CharmEvents):
+    """Kubernetes Multus Charm Events."""
 
     nad_config_changed = EventSource(NadConfigChangedEvent)
 
@@ -514,7 +515,7 @@ class KubernetesMultusCharmLib(Object):
             container_name: Container name
             cap_net_admin: Container requires NET_ADMIN capability
             privileged: Container requires privileged security context
-            refresh_event: A bound event which will be observed
+            refresh_event: A BoundEvent which will be observed
                 to configure_multus (e.g. NadConfigChangedEvent).
         """
         super().__init__(charm, "kubernetes-multus")

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -18,9 +18,19 @@
 from charms.kubernetes_charm_libraries.v0.multus import (
     KubernetesMultusCharmLib,
     NetworkAttachmentDefinition,
-    KubernetesMultusCharmEvents,
-    NetworkAnnotation,
+    NetworkAnnotation
 )
+
+class NadConfigChangedEvent(EventBase):
+
+    def __init__(self, handle: Handle):
+        super().__init__(handle)
+
+
+class KubernetesMultusCharmEvents(CharmEvents):
+
+    nad_config_changed = EventSource(NadConfigChangedEvent)
+
 
 class YourCharm(CharmBase):
 
@@ -104,8 +114,8 @@ from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import Pod
 from lightkube.types import PatchType
-from ops.charm import CharmBase, CharmEvents, RemoveEvent
-from ops.framework import BoundEvent, EventBase, EventSource, Handle, Object
+from ops.charm import CharmBase, RemoveEvent
+from ops.framework import BoundEvent, Object
 
 # The unique Charmhub library identifier, never change it
 LIBID = "75283550e3474e7b8b5b7724d345e3c2"
@@ -477,19 +487,6 @@ class KubernetesClient:
                 if privileged and not container.securityContext.privileged:
                     return False
         return True
-
-
-class NadConfigChangedEvent(EventBase):
-    """Event triggered when an existing network attachment definition is changed."""
-
-    def __init__(self, handle: Handle):
-        super().__init__(handle)
-
-
-class KubernetesMultusCharmEvents(CharmEvents):
-    """Kubernetes Multus Charm Events."""
-
-    nad_config_changed = EventSource(NadConfigChangedEvent)
 
 
 class KubernetesMultusCharmLib(Object):

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -11,6 +11,7 @@ from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import
     KubernetesClient,
     KubernetesMultusCharmLib,
     KubernetesMultusError,
+    NadConfigChangedCharmEvents,
     NetworkAnnotation,
     NetworkAttachmentDefinition,
 )
@@ -612,6 +613,8 @@ class TestKubernetes(unittest.TestCase):
 
 
 class _TestCharmNoNAD(CharmBase):
+    on = NadConfigChangedCharmEvents()
+
     def __init__(self, *args):
         super().__init__(*args)
         self.network_annotations = []
@@ -620,6 +623,7 @@ class _TestCharmNoNAD(CharmBase):
             network_attachment_definitions_func=self._network_annotations_func,
             network_annotations=self.network_annotations,
             container_name="container-name",
+            refresh_event=self.on.nad_config_changed,
         )
 
     def _network_annotations_func(self) -> list[NetworkAttachmentDefinition]:
@@ -627,6 +631,8 @@ class _TestCharmNoNAD(CharmBase):
 
 
 class _TestCharmMultipleNAD(CharmBase):
+    on = NadConfigChangedCharmEvents()
+
     def __init__(self, *args):
         super().__init__(*args)
         self.container_name = "container-name"
@@ -659,6 +665,7 @@ class _TestCharmMultipleNAD(CharmBase):
             network_attachment_definitions_func=self.network_attachment_definitions_func,
             network_annotations=self.network_annotations,
             container_name=self.container_name,
+            refresh_event=self.on.nad_config_changed,
         )
 
     def network_attachment_definitions_func(self) -> list[NetworkAttachmentDefinition]:
@@ -680,7 +687,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
-    def test_given_no_nad_to_create_and_no_existing_nad_when_config_changed_then_create_is_not_called(  # noqa: E501
+    def test_given_no_nad_to_create_and_no_existing_nad_when_nad_config_changed_then_create_is_not_called(  # noqa: E501
         self, patch_create_nad, patch_existing_nads
     ):
         patch_existing_nads.return_value = []
@@ -688,7 +695,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         self.addCleanup(harness.cleanup)
         harness.begin()
 
-        harness.charm.on.config_changed.emit()
+        harness.charm.on.nad_config_changed.emit()
 
         patch_create_nad.assert_not_called()
 
@@ -697,7 +704,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
-    def test_given_nads_already_exist_when_config_changed_then_create_is_not_called(
+    def test_given_nads_already_exist_when_nad_config_changed_then_create_is_not_called(
         self,
         patch_create_nad,
         patch_list_nads,
@@ -722,7 +729,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
             ),
         ]
 
-        harness.charm.on.config_changed.emit()
+        harness.charm.on.nad_config_changed.emit()
 
         patch_create_nad.assert_not_called()
 
@@ -731,7 +738,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
-    def test_given_nads_not_created_when_config_changed_then_nad_create_is_called(
+    def test_given_nads_not_created_when_nad_config_changed_then_nad_create_is_called(
         self, patch_create_nad, patch_list_nads
     ):
         patch_list_nads.return_value = []
@@ -739,7 +746,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         self.addCleanup(harness.cleanup)
         harness.begin()
 
-        harness.charm.on.config_changed.emit()
+        harness.charm.on.nad_config_changed.emit()
 
         patch_create_nad.assert_has_calls(
             calls=[
@@ -763,7 +770,24 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
-    def test_given_nads_exist_but_created_by_different_charm_when_config_changed_then_nad_create_is_called(  # noqa: E501
+    def test_given_nads_not_created_when_config_changed_then_nad_create_is_not_called(
+        self, patch_create_nad, patch_list_nads
+    ):
+        patch_list_nads.return_value = []
+        harness = Harness(_TestCharmMultipleNAD)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+
+        harness.charm.on.config_changed.emit()
+
+        patch_create_nad.assert_not_called()
+
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
+    def test_given_nads_exist_but_created_by_different_charm_when_nad_config_changed_then_nad_create_is_called(  # noqa: E501
         self, patch_create_nad, patch_list_nads
     ):
         harness = Harness(_TestCharmMultipleNAD)
@@ -786,7 +810,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
             ),
         ]
 
-        harness.charm.on.config_changed.emit()
+        harness.charm.on.nad_config_changed.emit()
 
         patch_create_nad.assert_has_calls(
             calls=[
@@ -813,7 +837,47 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
     )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition")
-    def test_given_nads_exist_but_are_differentwhen_config_changed_then_nad_delete_is_called(
+    def test_given_nads_exist_but_are_different_when_nad_config_changed_then_nad_delete_is_called(
+        self, patch_delete_nad, patch_list_nads
+    ):
+        harness = Harness(_TestCharmMultipleNAD)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        patch_list_nads.return_value = [
+            NetworkAttachmentDefinition(
+                metadata=ObjectMeta(
+                    name=harness.charm.nad_1_name,
+                    labels={"app.juju.is/created-by": harness.charm.app.name},
+                ),
+                spec={"different": "spec"},
+            ),
+            NetworkAttachmentDefinition(
+                metadata=ObjectMeta(
+                    name=harness.charm.nad_2_name,
+                    labels={"app.juju.is/created-by": harness.charm.app.name},
+                ),
+                spec={"different": "spec"},
+            ),
+        ]
+
+        harness.charm.on.nad_config_changed.emit()
+
+        patch_delete_nad.assert_has_calls(
+            calls=[
+                call(name=harness.charm.nad_1_name),
+                call(name=harness.charm.nad_2_name),
+            ]
+        )
+
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition")
+    def test_given_nads_exist_but_are_different_when_config_changed_then_nad_delete_is_not_called(
         self, patch_delete_nad, patch_list_nads
     ):
         harness = Harness(_TestCharmMultipleNAD)
@@ -838,19 +902,14 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
 
         harness.charm.on.config_changed.emit()
 
-        patch_delete_nad.assert_has_calls(
-            calls=[
-                call(name=harness.charm.nad_1_name),
-                call(name=harness.charm.nad_2_name),
-            ]
-        )
+        patch_delete_nad.assert_not_called()
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
-    def test_given_nads_exist_but_are_differentwhen_config_changed_then_nad_create_is_called(
+    def test_given_nads_exist_but_are_different_when_nad_config_changed_then_nad_create_is_called(
         self, patch_create_nad, patch_list_nads
     ):
         harness = Harness(_TestCharmMultipleNAD)
@@ -873,7 +932,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
             ),
         ]
 
-        harness.charm.on.config_changed.emit()
+        harness.charm.on.nad_config_changed.emit()
 
         patch_create_nad.assert_has_calls(
             calls=[
@@ -899,7 +958,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
     @patch(
         f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
     )
-    def test_given_nads_not_created_when_config_changed_then_patch_statefulset_is_called(
+    def test_given_nads_not_created_when_nad_config_changed_then_patch_statefulset_is_called(
         self, patch_is_statefulset_patched, patch_patch_statefulset, patch_list_nads
     ):
         patch_list_nads.return_value = []
@@ -908,7 +967,7 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         harness.begin()
         patch_is_statefulset_patched.return_value = False
 
-        harness.charm.on.config_changed.emit()
+        harness.charm.on.nad_config_changed.emit()
 
         patch_patch_statefulset.assert_called_with(
             name=harness.charm.app.name,

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -9,9 +9,9 @@ import httpx
 import pytest
 from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import]
     KubernetesClient,
+    KubernetesMultusCharmEvents,
     KubernetesMultusCharmLib,
     KubernetesMultusError,
-    NadConfigChangedCharmEvents,
     NetworkAnnotation,
     NetworkAttachmentDefinition,
 )
@@ -613,7 +613,7 @@ class TestKubernetes(unittest.TestCase):
 
 
 class _TestCharmNoNAD(CharmBase):
-    on = NadConfigChangedCharmEvents()
+    on = KubernetesMultusCharmEvents()
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -631,7 +631,7 @@ class _TestCharmNoNAD(CharmBase):
 
 
 class _TestCharmMultipleNAD(CharmBase):
-    on = NadConfigChangedCharmEvents()
+    on = KubernetesMultusCharmEvents()
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -9,7 +9,6 @@ import httpx
 import pytest
 from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import]
     KubernetesClient,
-    KubernetesMultusCharmEvents,
     KubernetesMultusCharmLib,
     KubernetesMultusError,
     NetworkAnnotation,
@@ -28,7 +27,8 @@ from lightkube.models.meta_v1 import LabelSelector, ObjectMeta
 from lightkube.resources.apps_v1 import StatefulSet as StatefulSetResource
 from lightkube.resources.core_v1 import Pod
 from lightkube.types import PatchType
-from ops.charm import CharmBase
+from ops import EventBase, EventSource, Handle
+from ops.charm import CharmBase, CharmEvents
 from ops.testing import Harness
 
 MULTUS_LIBRARY_PATH = "charms.kubernetes_charm_libraries.v0.multus"
@@ -610,6 +610,19 @@ class TestKubernetes(unittest.TestCase):
         self.kubernetes_multus.delete_pod(pod_name)
 
         patch_delete.assert_called_with(Pod, pod_name, namespace=self.namespace)
+
+
+class NadConfigChangedEvent(EventBase):
+    """Event triggered when an existing network attachment definition is changed."""
+
+    def __init__(self, handle: Handle):
+        super().__init__(handle)
+
+
+class KubernetesMultusCharmEvents(CharmEvents):
+    """Kubernetes Multus Charm Events."""
+
+    nad_config_changed = EventSource(NadConfigChangedEvent)
 
 
 class _TestCharmNoNAD(CharmBase):


### PR DESCRIPTION
# Description

Multus Library is acting for any config_changed event without config validation. This PR aims to solve https://github.com/canonical/kubernetes-charm-libraries/issues/16 by using custom event to trigger Multus configuration.
https://github.com/canonical/sdcore-upf-operator/pull/41 could be merged after merging this PR.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
