### PR TITLE
bugfix: Remove memory constraint when enabling HugePages

### DIFF
--- a/lib/charms/kubernetes_charm_libraries/v0/hugepages_volumes_patch.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/hugepages_volumes_patch.py
@@ -75,7 +75,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 
@@ -564,10 +564,8 @@ class KubernetesHugePagesPatchCharmLib(Object):
         for hugepage in self.hugepages_volumes_func():
             limits.update({f"hugepages-{hugepage.size}": hugepage.limit})
             limits.update({"cpu": "2"})
-            limits.update({"memory": "512Mi"})
             requests.update({f"hugepages-{hugepage.size}": hugepage.limit})
             requests.update({"cpu": "2"})
-            requests.update({"memory": "512Mi"})
         return ResourceRequirements(
             limits=limits,
             requests=requests,

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_hugepages_volumes_patch.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_hugepages_volumes_patch.py
@@ -751,12 +751,10 @@ class TestKubernetesHugePagesPatchCharmLib(unittest.TestCase):
             limits={
                 "hugepages-1Gi": "4Gi",
                 "cpu": "2",
-                "memory": "512Mi",
             },
             requests={
                 "hugepages-1Gi": "4Gi",
                 "cpu": "2",
-                "memory": "512Mi",
             },
         )
         current_podspec = PodSpec(
@@ -842,13 +840,11 @@ class TestKubernetesHugePagesPatchCharmLib(unittest.TestCase):
                 "a-limit": "a-value",
                 "hugepages-1Gi": "4Gi",
                 "cpu": "2",
-                "memory": "512Mi",
             },
             requests={
                 "a-request": "a-value",
                 "hugepages-1Gi": "4Gi",
                 "cpu": "2",
-                "memory": "512Mi",
             },
         )
         current_podspec = PodSpec(
@@ -909,12 +905,10 @@ class TestKubernetesHugePagesPatchCharmLib(unittest.TestCase):
                 limits={
                     "hugepages-1Gi": "4Gi",
                     "cpu": "2",
-                    "memory": "512Mi",
                 },
                 requests={
                     "hugepages-1Gi": "4Gi",
                     "cpu": "2",
-                    "memory": "512Mi",
                 },
             ),
         )


### PR DESCRIPTION
# Description

This PR aims to fix bug #20. Setting memory constraint to 512Mi when HugePages are disabled causes a process of UPF charm (`bessd`) failing at startup.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
