### PR TITLE
chore: add method to assess Multus availability

### DIFF
--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -657,6 +657,30 @@ class TestKubernetes(unittest.TestCase):
         with pytest.raises(KubernetesMultusError):
             self.kubernetes_multus.list_network_attachment_definitions()
 
+    @patch("lightkube.core.client.Client.list")
+    def test_given_multus_disabled_when_check_multus_then_returns_false(  # noqa: E501
+        self, patch_list
+    ):
+        patch_list.side_effect = httpx.HTTPStatusError(
+            message="",
+            request=httpx.Request(method="GET", url=""),
+            response=httpx.Response(status_code=404),
+        )
+
+        multus_is_available = self.kubernetes_multus.multus_is_available()
+
+        self.assertEqual(multus_is_available, False)
+
+    @patch("lightkube.core.client.Client.list")
+    def test_given_multus_enabled_when_check_multus_then_returns_true(  # noqa: E501
+        self, patch_list
+    ):
+        patch_list.return_value = ["whatever", "list", "content"]
+
+        multus_is_available = self.kubernetes_multus.multus_is_available()
+
+        self.assertEqual(multus_is_available, True)
+
     @patch("lightkube.core.client.Client.delete")
     def test_given_pod_is_deleted_when_delete_pod_then_client_delete_is_called_by_pod_name_and_namespace(  # noqa: E501
         self, patch_delete

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -672,6 +672,19 @@ class TestKubernetes(unittest.TestCase):
         self.assertEqual(multus_is_available, False)
 
     @patch("lightkube.core.client.Client.list")
+    def test_given_http_error_when_check_multus_then_then_multus_error_is_raised(  # noqa: E501
+        self, patch_list
+    ):
+        patch_list.side_effect = httpx.HTTPStatusError(
+            message="",
+            request=httpx.Request(method="GET", url=""),
+            response=httpx.Response(status_code=509),
+        )
+
+        with self.assertRaises(KubernetesMultusError):
+            self.kubernetes_multus.multus_is_available()
+
+    @patch("lightkube.core.client.Client.list")
     def test_given_multus_enabled_when_check_multus_then_returns_true(  # noqa: E501
         self, patch_list
     ):


### PR DESCRIPTION
# Description

This PR adds a method to assess Multus availability. This method will be used by charm requiring the library to set their status properly.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
