### PR TITLE
fix: freeze juju lib version to 3.3.0.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
-juju>=3.0
+juju==3.3.0.0
 mypy
 pep8-naming
 pyproject-flake8


### PR DESCRIPTION
# Description

The `juju` lib version got silently updated to 3.3.1.0 breaking unit tests. This PR freezes this dependency to the last working state.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
