### PR TITLE
chore: replace mypy with pyright

### DIFF
--- a/lib/charms/kubernetes_charm_libraries/v0/hugepages_volumes_patch.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/hugepages_volumes_patch.py
@@ -48,11 +48,12 @@ class YourCharm(CharmBase):
         ]
 
 """
+
 import logging
 from dataclasses import dataclass
 from typing import Callable, Iterable
 
-from lightkube import Client
+from lightkube.core.client import Client
 from lightkube.core.exceptions import ApiError
 from lightkube.models.apps_v1 import StatefulSetSpec
 from lightkube.models.core_v1 import (
@@ -75,7 +76,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,9 @@ class KubernetesClient:
         self.namespace = namespace
 
     @classmethod
-    def _get_container(cls, container_name: str, containers: Iterable[Container]) -> Container:
+    def _get_container(
+        cls, container_name: str, containers: Iterable[Container]
+    ) -> Container:
         """Find the container from the container list, assuming list is unique by name.
 
         Args:
@@ -120,9 +123,13 @@ class KubernetesClient:
             Container: An instance of :class:`Container` whose name matches the given name.
         """
         try:
-            return next(iter(filter(lambda ctr: ctr.name == container_name, containers)))
+            return next(
+                iter(filter(lambda ctr: ctr.name == container_name, containers))
+            )
         except StopIteration:
-            raise KubernetesHugePagesVolumesPatchError(f"Container `{container_name}` not found")
+            raise KubernetesHugePagesVolumesPatchError(
+                f"Container `{container_name}` not found"
+            )
 
     def pod_is_patched(
         self,
@@ -152,7 +159,9 @@ class KubernetesClient:
             if e.status.reason == "Unauthorized":
                 logger.debug("kube-apiserver not ready yet")
             else:
-                raise KubernetesHugePagesVolumesPatchError(f"Pod `{pod_name}` not found")
+                raise KubernetesHugePagesVolumesPatchError(
+                    f"Pod `{pod_name}` not found"
+                )
             return False
         pod_has_volumemounts = self._pod_contains_requested_volumemounts(
             requested_volumemounts=requested_volumemounts,
@@ -196,8 +205,10 @@ class KubernetesClient:
                     f"Could not get statefulset `{statefulset_name}`"
                 )
             return False
+        if not statefulset.spec:
+            return False
         return self._statefulset_contains_requested_volumes(
-            statefulset_spec=statefulset.spec,  # type: ignore[arg-type]
+            statefulset_spec=statefulset.spec,
             requested_volumes=requested_volumes,
         )
 
@@ -215,11 +226,11 @@ class KubernetesClient:
         Returns:
             bool: Whether the StatefulSet contains the given volumes.
         """
-        if not statefulset_spec.template.spec.volumes:  # type: ignore[union-attr]
+        if not statefulset_spec.template.spec.volumes:  # type: ignore[reportOptionalMemberAccess]
             return False
         return all(
             [
-                requested_volume in statefulset_spec.template.spec.volumes  # type: ignore[union-attr]  # noqa E501
+                requested_volume in statefulset_spec.template.spec.volumes  # type: ignore[reportOptionalMemberAccess]
                 for requested_volume in requested_volumes
             ]
         )
@@ -240,10 +251,12 @@ class KubernetesClient:
         Returns:
             bool: Whether container spec contains the given volumemounts.
         """
-        container = self._get_container(container_name=container_name, containers=containers)
+        container = self._get_container(
+            container_name=container_name, containers=containers
+        )
         return all(
             [
-                requested_volumemount in container.volumeMounts  # type: ignore[operator]
+                requested_volumemount in container.volumeMounts  # type: ignore[reportOperatorIssue]
                 for requested_volumemount in requested_volumemounts
             ]
         )
@@ -264,18 +277,20 @@ class KubernetesClient:
         Returns:
             bool: whether container spec contains the expected resources requests and limits.
         """
-        container = self._get_container(container_name=container_name, containers=containers)
+        container = self._get_container(
+            container_name=container_name, containers=containers
+        )
         if requested_resources.limits:
             for limit, value in requested_resources.limits.items():
-                if not container.resources.limits:  # type: ignore[union-attr]
+                if not container.resources.limits:  # type: ignore[reportOptionalMemberAccess]
                     return False
-                if container.resources.limits.get(limit) != value:  # type: ignore[union-attr]
+                if container.resources.limits.get(limit) != value:  # type: ignore[reportOptionalMemberAccess]
                     return False
         if requested_resources.requests:
             for request, value in requested_resources.requests.items():
-                if not container.resources.requests:  # type: ignore[union-attr]
+                if not container.resources.requests:  # type: ignore[reportOptionalMemberAccess]
                     return False
-                if container.resources.requests.get(request) != value:  # type: ignore[union-attr]
+                if container.resources.requests.get(request) != value:  # type: ignore[reportOptionalMemberAccess]
                     return False
         return True
 
@@ -308,11 +323,13 @@ class KubernetesClient:
             raise KubernetesHugePagesVolumesPatchError(
                 f"Could not get statefulset `{statefulset_name}`"
             )
-        containers: Iterable[Container] = statefulset.spec.template.spec.containers  # type: ignore[union-attr]  # noqa: E501
-        container = self._get_container(container_name=container_name, containers=containers)
-        container.volumeMounts = requested_volumemounts  # type: ignore[assignment]
+        containers: Iterable[Container] = statefulset.spec.template.spec.containers  # type: ignore[reportOptionalMemberAccess]
+        container = self._get_container(
+            container_name=container_name, containers=containers
+        )
+        container.volumeMounts = requested_volumemounts  # type: ignore[reportAttributeAccessIssue]
         container.resources = requested_resources
-        statefulset.spec.template.spec.volumes = requested_volumes  # type: ignore[union-attr]
+        statefulset.spec.template.spec.volumes = requested_volumes  # type: ignore[reportOptionalMemberAccess]
         try:
             self.client.replace(obj=statefulset)
         except ApiError:
@@ -342,9 +359,11 @@ class KubernetesClient:
             raise KubernetesHugePagesVolumesPatchError(
                 f"Could not get statefulset `{statefulset_name}`"
             )
-        return statefulset.spec.template.spec.volumes  # type: ignore[union-attr,return-value]
+        return statefulset.spec.template.spec.volumes  # type: ignore[reportOptionalMemberAccess]
 
-    def list_volumemounts(self, statefulset_name: str, container_name: str) -> list[VolumeMount]:
+    def list_volumemounts(
+        self, statefulset_name: str, container_name: str
+    ) -> list[VolumeMount]:
         """Lists current volume mounts in the given container.
 
         Args:
@@ -366,9 +385,11 @@ class KubernetesClient:
             raise KubernetesHugePagesVolumesPatchError(
                 f"Could not get statefulset `{statefulset_name}`"
             )
-        containers: Iterable[Container] = statefulset.spec.template.spec.containers  # type: ignore[union-attr]  # noqa: E501
-        container = self._get_container(container_name=container_name, containers=containers)
-        return container.volumeMounts  # type: ignore[return-value]
+        containers: Iterable[Container] = statefulset.spec.template.spec.containers  # type: ignore[reportOptionalMemberAccess]
+        container = self._get_container(
+            container_name=container_name, containers=containers
+        )
+        return container.volumeMounts if container.volumeMounts else []
 
     def list_container_resources(
         self, statefulset_name: str, container_name: str
@@ -394,10 +415,10 @@ class KubernetesClient:
             raise KubernetesHugePagesVolumesPatchError(
                 f"Could not get statefulset `{statefulset_name}`"
             )
-        containers: Iterable[
-            Container
-        ] = statefulset.spec.template.spec.containers  # type: ignore[union-attr]  # noqa: E501
-        container = self._get_container(container_name=container_name, containers=containers)
+        containers: Iterable[Container] = statefulset.spec.template.spec.containers  # type: ignore[union-attr]
+        container = self._get_container(
+            container_name=container_name, containers=containers
+        )
         return container.resources  # type: ignore[return-value]
 
 
@@ -459,7 +480,8 @@ class KubernetesHugePagesPatchCharmLib(Object):
                 [
                     self._volumemount_is_hugepages(x)
                     for x in self.kubernetes.list_volumemounts(
-                        statefulset_name=self.model.app.name, container_name=self.container_name
+                        statefulset_name=self.model.app.name,
+                        container_name=self.container_name,
                     )
                 ]
             )
@@ -518,7 +540,9 @@ class KubernetesHugePagesPatchCharmLib(Object):
         volumes = self._generate_volumes_from_requested_hugepage()
         statefulset_is_patched = self._statefulset_is_patched(volumes)
         volumemounts = self._generate_volumemounts_from_requested_hugepage()
-        resource_requirements = self._generate_resource_requirements_from_requested_hugepage()
+        resource_requirements = (
+            self._generate_resource_requirements_from_requested_hugepage()
+        )
         pod_is_patched = self._pod_is_patched(
             requested_volumemounts=volumemounts,
             requested_resources=resource_requirements,
@@ -534,7 +558,9 @@ class KubernetesHugePagesPatchCharmLib(Object):
         return [
             Volume(
                 name=f"hugepages-{requested_hugepages.size.lower()}",
-                emptyDir=EmptyDirVolumeSource(medium=f"HugePages-{requested_hugepages.size}"),
+                emptyDir=EmptyDirVolumeSource(
+                    medium=f"HugePages-{requested_hugepages.size}"
+                ),
             )
             for requested_hugepages in self.hugepages_volumes_func()
         ]
@@ -553,7 +579,9 @@ class KubernetesHugePagesPatchCharmLib(Object):
             for requested_hugepages in self.hugepages_volumes_func()
         ]
 
-    def _generate_resource_requirements_from_requested_hugepage(self) -> ResourceRequirements:
+    def _generate_resource_requirements_from_requested_hugepage(
+        self,
+    ) -> ResourceRequirements:
         """Generates the required resource requirements for HugePages.
 
         Returns:
@@ -627,10 +655,14 @@ class KubernetesHugePagesPatchCharmLib(Object):
             if not self._volumemount_is_hugepages(current_volumemount):
                 new_volumemounts.append(current_volumemount)
         if not new_volumemounts:
-            logger.warning("Container `%s` will have no volumeMounts", self.container_name)
+            logger.warning(
+                "Container `%s` will have no volumeMounts", self.container_name
+            )
         return new_volumemounts
 
-    def _remove_hugepages_from_resource_requirements(self, resource_attribute: dict) -> dict:
+    def _remove_hugepages_from_resource_requirements(
+        self, resource_attribute: dict
+    ) -> dict:
         """Removes HugePages-related keys from the given dictionary.
 
         Args:
@@ -657,7 +689,9 @@ class KubernetesHugePagesPatchCharmLib(Object):
         Returns:
             ResourceRequirements: new resource requirements to be replaced in the container.
         """
-        additional_resources = self._generate_resource_requirements_from_requested_hugepage()
+        additional_resources = (
+            self._generate_resource_requirements_from_requested_hugepage()
+        )
         current_resources = self.kubernetes.list_container_resources(
             statefulset_name=self.model.app.name, container_name=self.container_name
         )
@@ -668,12 +702,16 @@ class KubernetesHugePagesPatchCharmLib(Object):
             else {}
         )
         new_requests = (
-            self._remove_hugepages_from_resource_requirements(current_resources.requests)
+            self._remove_hugepages_from_resource_requirements(
+                current_resources.requests
+            )
             if current_resources.requests
             else {}
         )
-        new_limits = dict(new_limits.items() | additional_resources.limits.items())  # type: ignore[union-attr]  # noqa E501
-        new_requests = dict(new_requests.items() | additional_resources.requests.items())  # type: ignore[union-attr]  # noqa E501
+        new_limits = dict(new_limits.items() | additional_resources.limits.items())  # type: ignore[reportOptionalMemberAccess]
+        new_requests = dict(
+            new_requests.items() | additional_resources.requests.items()  # type: ignore[reportOptionalMemberAccess]
+        )
         new_resources = ResourceRequirements(
             limits=new_limits, requests=new_requests, claims=current_resources.claims
         )

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -97,9 +97,12 @@ from json.decoder import JSONDecodeError
 from typing import Callable, List, Optional, Union
 
 import httpx
-from lightkube import Client
+from lightkube.core.client import Client
 from lightkube.core.exceptions import ApiError
-from lightkube.generic_resource import GenericNamespacedResource, create_namespaced_resource
+from lightkube.generic_resource import (
+    GenericNamespacedResource,
+    create_namespaced_resource,
+)
 from lightkube.models.apps_v1 import StatefulSetSpec
 from lightkube.models.core_v1 import (
     Capabilities,
@@ -123,7 +126,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 
 logger = logging.getLogger(__name__)
@@ -136,11 +139,12 @@ _NetworkAttachmentDefinition = create_namespaced_resource(
 )
 
 
-class NetworkAttachmentDefinition(_NetworkAttachmentDefinition):  # type: ignore[valid-type, misc]
+class NetworkAttachmentDefinition(_NetworkAttachmentDefinition):
     """Object to represent Kubernetes Multus NetworkAttachmentDefinition."""
 
     def __eq__(self, other):
         """Validates equality between two NetworkAttachmentDefinitions object."""
+        assert self.metadata
         return self.metadata.name == other.metadata.name and self.spec == other.spec
 
 
@@ -225,7 +229,7 @@ class KubernetesClient:
                 raise KubernetesMultusError(f"Pod {pod_name} not found")
             return False
         return self._pod_is_patched(
-            pod=pod,  # type: ignore[arg-type]
+            pod=pod,
             network_annotations=network_annotations,
             container_name=container_name,
             cap_net_admin=cap_net_admin,
@@ -243,6 +247,8 @@ class KubernetesClient:
         Returns:
             bool: Whether the NetworkAttachmentDefinition is created
         """
+        assert network_attachment_definition.metadata
+        assert network_attachment_definition.metadata.name
         try:
             existing_nad = self.client.get(
                 res=NetworkAttachmentDefinition,
@@ -281,15 +287,21 @@ class KubernetesClient:
         Args:
             network_attachment_definition: NetworkAttachmentDefinition object
         """
+        assert network_attachment_definition.metadata
+        assert network_attachment_definition.metadata.name
         try:
-            self.client.create(obj=network_attachment_definition, namespace=self.namespace)  # type: ignore[call-overload]  # noqa: E501
+            self.client.create(  # type: ignore[call-overload]
+                obj=network_attachment_definition,
+                namespace=self.namespace,
+            )
         except ApiError:
             raise KubernetesMultusError(
                 f"Could not create NetworkAttachmentDefinition "
-                f"{network_attachment_definition.metadata.name}"  # type: ignore[union-attr]
+                f"{network_attachment_definition.metadata.name}"
             )
         logger.info(
-            "NetworkAttachmentDefinition %s created", network_attachment_definition.metadata.name  # type: ignore[union-attr]  # noqa: E501, W505
+            "NetworkAttachmentDefinition %s created",
+            network_attachment_definition.metadata.name,
         )
 
     def list_network_attachment_definitions(self) -> list[NetworkAttachmentDefinition]:
@@ -300,7 +312,9 @@ class KubernetesClient:
         """
         try:
             return list(
-                self.client.list(res=NetworkAttachmentDefinition, namespace=self.namespace)
+                self.client.list(
+                    res=NetworkAttachmentDefinition, namespace=self.namespace
+                )
             )
         except ApiError:
             raise KubernetesMultusError("Could not list NetworkAttachmentDefinitions")
@@ -316,7 +330,9 @@ class KubernetesClient:
                 res=NetworkAttachmentDefinition, name=name, namespace=self.namespace
             )
         except ApiError:
-            raise KubernetesMultusError(f"Could not delete NetworkAttachmentDefinition {name}")
+            raise KubernetesMultusError(
+                f"Could not delete NetworkAttachmentDefinition {name}"
+            )
         logger.info("NetworkAttachmentDefinition %s deleted", name)
 
     def patch_statefulset(
@@ -340,7 +356,9 @@ class KubernetesClient:
             logger.info("No network annotations were provided")
             return
         try:
-            statefulset = self.client.get(res=StatefulSet, name=name, namespace=self.namespace)
+            statefulset = self.client.get(
+                res=StatefulSet, name=name, namespace=self.namespace
+            )
         except ApiError:
             raise KubernetesMultusError(f"Could not get statefulset {name}")
         container = Container(name=container_name)
@@ -398,7 +416,9 @@ class KubernetesClient:
             container_name: Container name
         """
         try:
-            statefulset = self.client.get(res=StatefulSet, name=name, namespace=self.namespace)
+            statefulset = self.client.get(
+                res=StatefulSet, name=name, namespace=self.namespace
+            )
         except ApiError:
             raise KubernetesMultusError(f"Could not get statefulset {name}")
 
@@ -417,7 +437,9 @@ class KubernetesClient:
                 serviceName=statefulset.spec.serviceName,  # type: ignore[union-attr]
                 template=PodTemplateSpec(
                     metadata=ObjectMeta(
-                        annotations={NetworkAnnotation.NETWORK_ANNOTATION_RESOURCE_KEY: "[]"}
+                        annotations={
+                            NetworkAnnotation.NETWORK_ANNOTATION_RESOURCE_KEY: "[]"
+                        }
                     ),
                     spec=PodSpec(containers=[container]),
                 ),
@@ -433,7 +455,9 @@ class KubernetesClient:
                 field_manager=self.__class__.__name__,
             )
         except ApiError:
-            raise KubernetesMultusError(f"Could not remove patches from statefulset {name}")
+            raise KubernetesMultusError(
+                f"Could not remove patches from statefulset {name}"
+            )
         logger.info("Multus annotation removed from %s statefulset", name)
 
     def statefulset_is_patched(
@@ -457,19 +481,23 @@ class KubernetesClient:
             bool: Whether the statefulset has the expected multus annotation.
         """
         try:
-            statefulset = self.client.get(res=StatefulSet, name=name, namespace=self.namespace)
+            statefulset = self.client.get(
+                res=StatefulSet, name=name, namespace=self.namespace
+            )
         except ApiError as e:
             if e.status.reason == "Unauthorized":
                 logger.debug("kube-apiserver not ready yet")
             else:
                 raise KubernetesMultusError(f"Could not get statefulset {name}")
             return False
+        if not statefulset.spec:
+            return False
         return self._pod_is_patched(
             container_name=container_name,
             cap_net_admin=cap_net_admin,
             privileged=privileged,
             network_annotations=network_annotations,
-            pod=statefulset.spec.template,  # type: ignore[union-attr]
+            pod=statefulset.spec.template,
         )
 
     def _pod_is_patched(
@@ -493,12 +521,12 @@ class KubernetesClient:
             bool
         """
         if not self._annotations_contains_multus_networks(
-            annotations=pod.metadata.annotations,  # type: ignore[arg-type,union-attr]
+            annotations=pod.metadata.annotations,  # type: ignore[reportOptionalMemberAccess]
             network_annotations=network_annotations,
         ):
             return False
         if not self._container_security_context_is_set(
-            containers=pod.spec.containers,  # type: ignore[union-attr]
+            containers=pod.spec.containers,  # type: ignore[reportOptionalMemberAccess]
             container_name=container_name,
             cap_net_admin=cap_net_admin,
             privileged=privileged,
@@ -513,7 +541,9 @@ class KubernetesClient:
         if NetworkAnnotation.NETWORK_ANNOTATION_RESOURCE_KEY not in annotations:
             return False
         try:
-            if json.loads(annotations[NetworkAnnotation.NETWORK_ANNOTATION_RESOURCE_KEY]) != [
+            if json.loads(
+                annotations[NetworkAnnotation.NETWORK_ANNOTATION_RESOURCE_KEY]
+            ) != [
                 network_annotation.dict() for network_annotation in network_annotations
             ]:
                 return False
@@ -541,9 +571,12 @@ class KubernetesClient:
         """
         for container in containers:
             if container.name == container_name:
-                if cap_net_admin and "NET_ADMIN" not in container.securityContext.capabilities.add:  # type: ignore[operator,union-attr]  # noqa E501
+                if (
+                    cap_net_admin
+                    and "NET_ADMIN" not in container.securityContext.capabilities.add  # type: ignore[operator,union-attr]
+                ):
                     return False
-                if privileged and not container.securityContext.privileged:  # type: ignore[union-attr]  # noqa E501
+                if privileged and not container.securityContext.privileged:  # type: ignore[union-attr]
                     return False
         return True
 
@@ -554,7 +587,11 @@ class KubernetesClient:
             bool: Whether Multus is enabled
         """
         try:
-            list(self.client.list(res=NetworkAttachmentDefinition, namespace=self.namespace))
+            list(
+                self.client.list(
+                    res=NetworkAttachmentDefinition, namespace=self.namespace
+                )
+            )
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
                 return False
@@ -571,7 +608,9 @@ class KubernetesMultusCharmLib(Object):
     def __init__(
         self,
         charm: CharmBase,
-        network_attachment_definitions_func: Callable[[], list[NetworkAttachmentDefinition]],
+        network_attachment_definitions_func: Callable[
+            [], list[NetworkAttachmentDefinition]
+        ],
         network_annotations_func: Callable[[], list[NetworkAnnotation]],
         container_name: str,
         refresh_event: BoundEvent,
@@ -623,7 +662,7 @@ class KubernetesMultusCharmLib(Object):
         self, network_attachment_definition: NetworkAttachmentDefinition
     ) -> bool:
         """Returns whether a given NetworkAttachmentDefinitions was created by this charm."""
-        labels = network_attachment_definition.metadata.labels
+        labels = network_attachment_definition.metadata.labels  # type: ignore[reportOptionalMemberAccess]
         if not labels:
             return False
         if "app.juju.is/created-by" not in labels:
@@ -644,7 +683,9 @@ class KubernetesMultusCharmLib(Object):
         3. Detects the NAD config changes and triggers pod restart
            if any there is any modification in existing NADs
         """
-        network_attachment_definitions_to_create = self.network_attachment_definitions_func()
+        network_attachment_definitions_to_create = (
+            self.network_attachment_definitions_func()
+        )
         nad_config_changed = False
         for (
             existing_network_attachment_definition
@@ -656,6 +697,12 @@ class KubernetesMultusCharmLib(Object):
                     existing_network_attachment_definition
                     not in network_attachment_definitions_to_create
                 ):
+                    if not existing_network_attachment_definition.metadata:
+                        logger.warning("NetworkAttachmentDefinition has no metadata")
+                        continue
+                    if not existing_network_attachment_definition.metadata.name:
+                        logger.warning("NetworkAttachmentDefinition has no name")
+                        continue
                     self.kubernetes.delete_network_attachment_definition(
                         name=existing_network_attachment_definition.metadata.name
                     )
@@ -664,7 +711,9 @@ class KubernetesMultusCharmLib(Object):
                     network_attachment_definitions_to_create.remove(
                         existing_network_attachment_definition
                     )
-        for network_attachment_definition_to_create in network_attachment_definitions_to_create:
+        for (
+            network_attachment_definition_to_create
+        ) in network_attachment_definitions_to_create:
             self.kubernetes.create_network_attachment_definition(
                 network_attachment_definition=network_attachment_definition_to_create
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,24 +9,8 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
-line-length = 99
-target-version = ["py38"]
-
-[tool.isort]
-line_length = 99
-profile = "black"
-
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore D107 Missing docstring in __init__
-ignore = ["D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.ruff_cache,.coverage"

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,14 +1,7 @@
-black
+codespell
 coverage[toml]
-flake8-docstrings
-flake8-builtins
-isort
 juju==3.5.2.0
-mypy
-pep8-naming
-pyproject-flake8
+pyright
 pytest
 pytest-operator
-types-PyYAML
-types-setuptools
-types-toml
+ruff

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,27 +6,26 @@
 #
 asttokens==2.4.1
     # via stack-data
-bcrypt==4.1.3
+bcrypt==4.2.0
     # via paramiko
-black==24.8.0
-    # via -r test-requirements.in
-cachetools==5.3.3
+cachetools==5.4.0
     # via google-auth
 certifi==2024.7.4
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
-cffi==1.16.0
+cffi==1.17.0
     # via
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
-    # via black
+codespell==2.3.0
+    # via -r test-requirements.in
 coverage[toml]==7.6.1
     # via -r test-requirements.in
-cryptography==42.0.8
+cryptography==43.0.0
     # via paramiko
 decorator==5.1.1
     # via
@@ -34,30 +33,20 @@ decorator==5.1.1
     #   ipython
 executing==2.0.1
     # via stack-data
-flake8==7.0.0
-    # via
-    #   flake8-builtins
-    #   flake8-docstrings
-    #   pep8-naming
-    #   pyproject-flake8
-flake8-builtins==2.5.0
-    # via -r test-requirements.in
-flake8-docstrings==1.7.0
-    # via -r test-requirements.in
-google-auth==2.31.0
+google-auth==2.33.0
     # via kubernetes
 hvac==2.3.0
     # via juju
 idna==3.7
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.26.0
     # via ipdb
-isort==5.13.2
-    # via -r test-requirements.in
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
@@ -74,45 +63,33 @@ markupsafe==2.1.5
     # via jinja2
 matplotlib-inline==0.1.7
     # via ipython
-mccabe==0.7.0
-    # via flake8
-mypy==1.11.1
-    # via -r test-requirements.in
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
+    # via typing-inspect
+nodeenv==1.9.1
+    # via pyright
 oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
 packaging==24.1
     # via
-    #   black
     #   juju
     #   pytest
 paramiko==3.4.0
     # via juju
 parso==0.8.4
     # via jedi
-pathspec==0.12.1
-    # via black
-pep8-naming==0.14.1
-    # via -r test-requirements.in
 pexpect==4.9.0
     # via ipython
-platformdirs==4.2.2
-    # via black
 pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 pyasn1==0.6.0
     # via
@@ -121,14 +98,8 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-pycodestyle==2.11.1
-    # via flake8
 pycparser==2.22
     # via cffi
-pydocstyle==6.3.0
-    # via flake8-docstrings
-pyflakes==3.2.0
-    # via flake8
 pygments==2.18.0
     # via ipython
 pymacaroons==0.13.0
@@ -138,12 +109,12 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyproject-flake8==7.0.0
-    # via -r test-requirements.in
 pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
+pyright==1.1.375
+    # via -r test-requirements.in
 pytest==8.3.2
     # via
     #   -r test-requirements.in
@@ -151,7 +122,7 @@ pytest==8.3.2
     #   pytest-operator
 pytest-asyncio==0.21.2
     # via pytest-operator
-pytest-operator==0.35.0
+pytest-operator==0.36.0
     # via -r test-requirements.in
 python-dateutil==2.9.0.post0
     # via kubernetes
@@ -159,6 +130,7 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
@@ -172,6 +144,8 @@ requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruff==0.5.6
+    # via -r test-requirements.in
 six==1.16.0
     # via
     #   asttokens
@@ -179,8 +153,6 @@ six==1.16.0
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 stack-data==0.6.3
     # via ipython
 toposort==1.10
@@ -189,16 +161,8 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-types-pyyaml==6.0.12.20240724
-    # via -r test-requirements.in
-types-setuptools==71.1.0.20240726
-    # via -r test-requirements.in
-types-toml==0.10.8.20240310
-    # via -r test-requirements.in
 typing-extensions==4.12.2
-    # via
-    #   mypy
-    #   typing-inspect
+    # via typing-inspect
 typing-inspect==0.9.0
     # via juju
 urllib3==2.2.2
@@ -208,6 +172,8 @@ urllib3==2.2.2
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_hugepages_volumes_patch.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_hugepages_volumes_patch.py
@@ -5,7 +5,7 @@ from copy import copy
 from unittest.mock import Mock, patch
 
 import httpx
-from charms.kubernetes_charm_libraries.v0.hugepages_volumes_patch import (  # type: ignore[import]  # noqa E501
+from charms.kubernetes_charm_libraries.v0.hugepages_volumes_patch import (
     HugePagesVolume,
     KubernetesClient,
     KubernetesHugePagesPatchCharmLib,
@@ -75,8 +75,12 @@ class TestKubernetesClient(unittest.TestCase):
         patch_get.return_value = initial_statefulset
 
         expected_statefulset = copy(initial_statefulset)
+        assert expected_statefulset.spec
+        assert expected_statefulset.spec.template.spec
         expected_statefulset.spec.template.spec.volumes = requested_volumes
-        expected_statefulset.spec.template.spec.containers[0].volumeMounts = requested_volumemounts
+        expected_statefulset.spec.template.spec.containers[
+            0
+        ].volumeMounts = requested_volumemounts
 
         self.kubernetes_volumes.replace_statefulset(
             statefulset_name=STATEFULSET_NAME,
@@ -104,7 +108,9 @@ class TestKubernetesClient(unittest.TestCase):
         requested_resources = ResourceRequirements()
         patch_get.side_effect = ApiError(
             request=httpx.Request(method="GET", url="http://whatever.com"),
-            response=httpx.Response(status_code=500, json={"reason": "Internal Server Error"}),
+            response=httpx.Response(
+                status_code=500, json={"reason": "Internal Server Error"}
+            ),
         )
         with self.assertRaises(KubernetesHugePagesVolumesPatchError):
             self.kubernetes_volumes.replace_statefulset(
@@ -145,7 +151,9 @@ class TestKubernetesClient(unittest.TestCase):
         patch_get.return_value = initial_statefulset
         patch_replace.side_effect = ApiError(
             request=httpx.Request(method="GET", url="http://whatever.com"),
-            response=httpx.Response(status_code=500, json={"reason": "Internal Server Error"}),
+            response=httpx.Response(
+                status_code=500, json={"reason": "Internal Server Error"}
+            ),
         )
         with self.assertRaises(KubernetesHugePagesVolumesPatchError):
             self.kubernetes_volumes.replace_statefulset(
@@ -165,7 +173,9 @@ class TestKubernetesClient(unittest.TestCase):
         ]
         patch_get.side_effect = ApiError(
             request=httpx.Request(method="GET", url="http://whatever.com"),
-            response=httpx.Response(status_code=500, json={"reason": "Internal Server Error"}),
+            response=httpx.Response(
+                status_code=500, json={"reason": "Internal Server Error"}
+            ),
         )
         with self.assertRaises(KubernetesHugePagesVolumesPatchError):
             self.kubernetes_volumes.statefulset_is_patched(
@@ -224,10 +234,15 @@ class TestKubernetesClient(unittest.TestCase):
         self, patch_get
     ):
         requested_volumes_in_statefulset = [
-            Volume(name="a-volume-existing", emptyDir=EmptyDirVolumeSource(medium="a-medium")),
+            Volume(
+                name="a-volume-existing",
+                emptyDir=EmptyDirVolumeSource(medium="a-medium"),
+            ),
         ]
         requested_volumes = [
-            Volume(name="a-volume-new", emptyDir=EmptyDirVolumeSource(medium="a-medium")),
+            Volume(
+                name="a-volume-new", emptyDir=EmptyDirVolumeSource(medium="a-medium")
+            ),
         ]
         patch_get.return_value = StatefulSet(
             spec=StatefulSetSpec(
@@ -282,7 +297,9 @@ class TestKubernetesClient(unittest.TestCase):
     ):
         patch_get.side_effect = ApiError(
             request=httpx.Request(method="GET", url="http://whatever.com"),
-            response=httpx.Response(status_code=500, json={"reason": "Internal Server Error"}),
+            response=httpx.Response(
+                status_code=500, json={"reason": "Internal Server Error"}
+            ),
         )
         requested_volumemounts = [
             VolumeMount(
@@ -390,7 +407,9 @@ class TestKubernetesClient(unittest.TestCase):
         self.assertFalse(is_patched)
 
     @patch("lightkube.core.client.Client.get")
-    def test_given_pod_is_patched_when_pod_is_patched_then_returns_true(self, patch_get):
+    def test_given_pod_is_patched_when_pod_is_patched_then_returns_true(
+        self, patch_get
+    ):
         requested_volumemounts = [
             VolumeMount(
                 name="a-volume-mount",
@@ -485,7 +504,9 @@ class TestKubernetesClient(unittest.TestCase):
     ):
         patch_get.side_effect = ApiError(
             request=httpx.Request(method="GET", url="http://whatever.com"),
-            response=httpx.Response(status_code=500, json={"reason": "Internal Server Error"}),
+            response=httpx.Response(
+                status_code=500, json={"reason": "Internal Server Error"}
+            ),
         )
         with self.assertRaises(KubernetesHugePagesVolumesPatchError):
             self.kubernetes_volumes.list_volumes(
@@ -530,7 +551,9 @@ class TestKubernetesClient(unittest.TestCase):
     ):
         patch_get.side_effect = ApiError(
             request=httpx.Request(method="GET", url="http://whatever.com"),
-            response=httpx.Response(status_code=500, json={"reason": "Internal Server Error"}),
+            response=httpx.Response(
+                status_code=500, json={"reason": "Internal Server Error"}
+            ),
         )
         with self.assertRaises(KubernetesHugePagesVolumesPatchError):
             self.kubernetes_volumes.list_volumemounts(
@@ -539,8 +562,12 @@ class TestKubernetesClient(unittest.TestCase):
             )
 
     @patch("lightkube.core.client.Client.get")
-    def test_list_container_resources_returns_container_resource_requirements(self, patch_get):
-        expected_resource_requirements = ResourceRequirements(limits={"a-limit": "a-value"})
+    def test_list_container_resources_returns_container_resource_requirements(
+        self, patch_get
+    ):
+        expected_resource_requirements = ResourceRequirements(
+            limits={"a-limit": "a-value"}
+        )
         patch_get.return_value = StatefulSet(
             spec=StatefulSetSpec(
                 selector=LabelSelector(),
@@ -571,7 +598,9 @@ class TestKubernetesClient(unittest.TestCase):
     ):
         patch_get.side_effect = ApiError(
             request=httpx.Request(method="GET", url="http://whatever.com"),
-            response=httpx.Response(status_code=500, json={"reason": "Internal Server Error"}),
+            response=httpx.Response(
+                status_code=500, json={"reason": "Internal Server Error"}
+            ),
         )
         with self.assertRaises(KubernetesHugePagesVolumesPatchError):
             self.kubernetes_volumes.list_container_resources(
@@ -591,7 +620,7 @@ class K8sHugePagesVolumePatchChangedCharmEvents(CharmEvents):
 
 
 class _TestCharmNoVolumes(CharmBase):
-    on = K8sHugePagesVolumePatchChangedCharmEvents()
+    on = K8sHugePagesVolumePatchChangedCharmEvents()  # type: ignore
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -608,7 +637,7 @@ class _TestCharmNoVolumes(CharmBase):
 
 
 class _TestCharmAddVolumes(CharmBase):
-    on = K8sHugePagesVolumePatchChangedCharmEvents()
+    on = K8sHugePagesVolumePatchChangedCharmEvents()  # type: ignore
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -673,9 +702,14 @@ class TestKubernetesHugePagesPatchCharmLib(unittest.TestCase):
         patch_get,
     ):
         current_volumes = [
-            Volume(name="hugepages-1gi", emptyDir=EmptyDirVolumeSource(medium="HugePages-1Gi"))
+            Volume(
+                name="hugepages-1gi",
+                emptyDir=EmptyDirVolumeSource(medium="HugePages-1Gi"),
+            )
         ]
-        current_volumemounts = [VolumeMount(name="hugepages-1gi", mountPath="/dev/hugepages")]
+        current_volumemounts = [
+            VolumeMount(name="hugepages-1gi", mountPath="/dev/hugepages")
+        ]
         current_resources = ResourceRequirements(
             limits={"hugepages-1gi": "4Gi"},
             requests={"hugepages-1gi": "4Gi"},
@@ -720,7 +754,9 @@ class TestKubernetesHugePagesPatchCharmLib(unittest.TestCase):
             container_name=CONTAINER_NAME,
             requested_volumes=[],
             requested_volumemounts=[],
-            requested_resources=ResourceRequirements(claims=None, limits={}, requests={}),
+            requested_resources=ResourceRequirements(
+                claims=None, limits={}, requests={}
+            ),
         )
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
@@ -926,5 +962,10 @@ class TestKubernetesHugePagesPatchCharmLib(unittest.TestCase):
 
         self.assertEqual(
             generated_volumes,
-            [Volume(name="hugepages-1gi", emptyDir=EmptyDirVolumeSource(medium="HugePages-1Gi"))],
+            [
+                Volume(
+                    name="hugepages-1gi",
+                    emptyDir=EmptyDirVolumeSource(medium="HugePages-1Gi"),
+                )
+            ],
         )

--- a/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
+++ b/tests/unit/lib/charms/kubernetes_charm_libraries/v0/test_multus.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, call, patch
 
 import httpx
 import pytest
-from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import]
+from charms.kubernetes_charm_libraries.v0.multus import (
     KubernetesClient,
     KubernetesMultusCharmLib,
     KubernetesMultusError,
@@ -44,7 +44,9 @@ class TestKubernetes(unittest.TestCase):
     def test_given_k8s_existing_nad_identical_to_new_one_when_nad_is_created_then_return_true(
         self, patch_get
     ):
-        existing_nad = NetworkAttachmentDefinition(metadata=ObjectMeta(name="whatever name"))
+        existing_nad = NetworkAttachmentDefinition(
+            metadata=ObjectMeta(name="whatever name")
+        )
         patch_get.return_value = existing_nad
 
         is_created = self.kubernetes_multus.network_attachment_definition_is_created(
@@ -94,7 +96,9 @@ class TestKubernetes(unittest.TestCase):
         nad_name = "whatever name"
         patch_get.side_effect = ApiError(
             request=httpx.Request(method="GET", url="http://whatever.com"),
-            response=httpx.Response(status_code=400, json={"reason": "whatever reason"}),
+            response=httpx.Response(
+                status_code=400, json={"reason": "whatever reason"}
+            ),
         )
 
         with pytest.raises(KubernetesMultusError) as e:
@@ -237,11 +241,20 @@ class TestKubernetes(unittest.TestCase):
         self.assertEqual(kwargs["res"], StatefulSetResource)
         self.assertEqual(kwargs["name"], statefulset_name)
         self.assertEqual(
-            kwargs["obj"].spec.template.metadata.annotations["k8s.v1.cni.cncf.io/networks"],
-            json.dumps([network_annotation.dict() for network_annotation in network_annotations]),
+            kwargs["obj"].spec.template.metadata.annotations[
+                "k8s.v1.cni.cncf.io/networks"
+            ],
+            json.dumps(
+                [
+                    network_annotation.dict()
+                    for network_annotation in network_annotations
+                ]
+            ),
         )
         self.assertEqual(
-            kwargs["obj"].spec.template.spec.containers[0].securityContext.capabilities.add,
+            kwargs["obj"]
+            .spec.template.spec.containers[0]
+            .securityContext.capabilities.add,
             ["NET_ADMIN"],
         )
         self.assertEqual(kwargs["patch_type"], PatchType.APPLY)
@@ -299,8 +312,15 @@ class TestKubernetes(unittest.TestCase):
 
         args, kwargs = patch_patch.call_args
         self.assertEqual(
-            kwargs["obj"].spec.template.metadata.annotations["k8s.v1.cni.cncf.io/networks"],
-            json.dumps([network_annotation.dict() for network_annotation in network_annotations]),
+            kwargs["obj"].spec.template.metadata.annotations[
+                "k8s.v1.cni.cncf.io/networks"
+            ],
+            json.dumps(
+                [
+                    network_annotation.dict()
+                    for network_annotation in network_annotations
+                ]
+            ),
         )
 
     @patch("lightkube.core.client.Client.get")
@@ -328,7 +348,9 @@ class TestKubernetes(unittest.TestCase):
         self.assertFalse(is_patched)
 
     @patch("lightkube.core.client.Client.get")
-    def test_given_no_annotations_when_statefulset_is_patched_then_returns_false(self, patch_get):
+    def test_given_no_annotations_when_statefulset_is_patched_then_returns_false(
+        self, patch_get
+    ):
         statefulset_name = "whatever name"
         network_annotations = [
             NetworkAnnotation(interface="whatever interface 1", name="whatever name 1"),
@@ -366,8 +388,12 @@ class TestKubernetes(unittest.TestCase):
             NetworkAnnotation(interface="whatever interface 2", name="whatever name 2"),
         ]
         network_annotations = [
-            NetworkAnnotation(interface="whatever new interface 1", name="whatever new name 1"),
-            NetworkAnnotation(interface="whatever new interface 2", name="whatever new name 2"),
+            NetworkAnnotation(
+                interface="whatever new interface 1", name="whatever new name 1"
+            ),
+            NetworkAnnotation(
+                interface="whatever new interface 2", name="whatever new name 2"
+            ),
         ]
         patch_get.return_value = StatefulSet(
             spec=StatefulSetSpec(
@@ -515,7 +541,9 @@ class TestKubernetes(unittest.TestCase):
         is_ready = self.kubernetes_multus.pod_is_ready(
             pod_name="pod name",
             network_annotations=[
-                NetworkAnnotation(interface="whatever interface 1", name="whatever name 1")
+                NetworkAnnotation(
+                    interface="whatever interface 1", name="whatever name 1"
+                )
             ],
             container_name="container-name",
             cap_net_admin=False,
@@ -525,13 +553,17 @@ class TestKubernetes(unittest.TestCase):
         self.assertFalse(is_ready)
 
     @patch("lightkube.core.client.Client.get")
-    def test_given_annotation_not_set_when_pod_is_ready_then_returns_false(self, patch_get):
+    def test_given_annotation_not_set_when_pod_is_ready_then_returns_false(
+        self, patch_get
+    ):
         patch_get.return_value = Pod(metadata=ObjectMeta(annotations={}))
 
         is_ready = self.kubernetes_multus.pod_is_ready(
             pod_name="pod name",
             network_annotations=[
-                NetworkAnnotation(interface="whatever interface 1", name="whatever name 1")
+                NetworkAnnotation(
+                    interface="whatever interface 1", name="whatever name 1"
+                )
             ],
             container_name="container-name",
             cap_net_admin=False,
@@ -541,7 +573,9 @@ class TestKubernetes(unittest.TestCase):
         self.assertFalse(is_ready)
 
     @patch("lightkube.core.client.Client.get")
-    def test_given_annotation_badly_set_when_pod_is_ready_then_returns_false(self, patch_get):
+    def test_given_annotation_badly_set_when_pod_is_ready_then_returns_false(
+        self, patch_get
+    ):
         existing_network_annotation = NetworkAnnotation(
             interface="whatever requested interface", name="whatever existing name"
         )
@@ -551,7 +585,9 @@ class TestKubernetes(unittest.TestCase):
         patch_get.return_value = Pod(
             metadata=ObjectMeta(
                 annotations={
-                    "k8s.v1.cni.cncf.io/networks": json.dumps([existing_network_annotation.dict()])
+                    "k8s.v1.cni.cncf.io/networks": json.dumps(
+                        [existing_network_annotation.dict()]
+                    )
                 }
             )
         )
@@ -567,7 +603,9 @@ class TestKubernetes(unittest.TestCase):
         self.assertFalse(is_ready)
 
     @patch("lightkube.core.client.Client.get")
-    def test_given_net_admin_not_set_when_pod_is_ready_then_returns_false(self, patch_get):
+    def test_given_net_admin_not_set_when_pod_is_ready_then_returns_false(
+        self, patch_get
+    ):
         network_annotation = NetworkAnnotation(
             interface="whatever requested interface", name="whatever existing name"
         )
@@ -575,14 +613,18 @@ class TestKubernetes(unittest.TestCase):
         patch_get.return_value = Pod(
             metadata=ObjectMeta(
                 annotations={
-                    "k8s.v1.cni.cncf.io/networks": json.dumps([network_annotation.dict()])
+                    "k8s.v1.cni.cncf.io/networks": json.dumps(
+                        [network_annotation.dict()]
+                    )
                 }
             ),
             spec=PodSpec(
                 containers=[
                     Container(
                         name=container_name,
-                        securityContext=SecurityContext(capabilities=Capabilities(add=[])),
+                        securityContext=SecurityContext(
+                            capabilities=Capabilities(add=[])
+                        ),
                     ),
                 ]
             ),
@@ -607,7 +649,9 @@ class TestKubernetes(unittest.TestCase):
         patch_get.return_value = Pod(
             metadata=ObjectMeta(
                 annotations={
-                    "k8s.v1.cni.cncf.io/networks": json.dumps([network_annotation.dict()])
+                    "k8s.v1.cni.cncf.io/networks": json.dumps(
+                        [network_annotation.dict()]
+                    )
                 }
             ),
             spec=PodSpec(
@@ -719,7 +763,7 @@ class KubernetesMultusCharmEvents(CharmEvents):
 
 
 class _TestCharmNoNAD(CharmBase):
-    on = KubernetesMultusCharmEvents()
+    on = KubernetesMultusCharmEvents()  # type: ignore
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -741,7 +785,7 @@ class _TestCharmNoNAD(CharmBase):
 
 
 class _TestCharmMultipleNAD(CharmBase):
-    on = KubernetesMultusCharmEvents()
+    on = KubernetesMultusCharmEvents()  # type: ignore
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -795,10 +839,14 @@ class _TestCharmMultipleNAD(CharmBase):
 
 class TestKubernetesMultusCharmLib(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition"
+    )
     def test_given_no_nad_to_create_and_no_existing_nad_when_nad_config_changed_then_create_is_not_called(  # noqa: E501
         self, patch_create_nad, patch_existing_nads
     ):
@@ -812,10 +860,14 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         patch_create_nad.assert_not_called()
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition"
+    )
     def test_given_nads_already_exist_when_nad_config_changed_then_create_is_not_called(
         self,
         patch_create_nad,
@@ -846,10 +898,14 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         patch_create_nad.assert_not_called()
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition"
+    )
     def test_given_nads_not_created_when_nad_config_changed_then_nad_create_is_called(
         self, patch_create_nad, patch_list_nads
     ):
@@ -878,10 +934,14 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         )
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition"
+    )
     def test_given_nads_not_created_when_config_changed_then_nad_create_is_not_called(
         self, patch_create_nad, patch_list_nads
     ):
@@ -895,10 +955,14 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         patch_create_nad.assert_not_called()
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition"
+    )
     def test_given_nads_exist_but_created_by_different_charm_when_nad_config_changed_then_nad_create_is_called(  # noqa: E501
         self, patch_create_nad, patch_list_nads
     ):
@@ -942,13 +1006,18 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         )
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(
-        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition",
+        new=Mock,
     )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition"
+    )
     def test_given_nads_exist_but_are_different_when_nad_config_changed_then_nad_delete_is_called(
         self, patch_delete_nad, patch_list_nads
     ):
@@ -982,13 +1051,18 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         )
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(
-        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition",
+        new=Mock,
     )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition"
+    )
     def test_given_nads_exist_but_are_different_when_config_changed_then_nad_delete_is_not_called(
         self, patch_delete_nad, patch_list_nads
     ):
@@ -1018,14 +1092,18 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_pod")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(
-        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition",
+        new=Mock,
     )
     @patch(
-        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition", new=Mock
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition",
+        new=Mock,
     )
     def test_given_nads_exist_but_they_are_different_when_nad_config_changed_then_pod_delete_is_called_once(  # noqa: E501
         self, patch_list_nads, patch_delete_pod
@@ -1054,14 +1132,18 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_pod")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(
-        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition",
+        new=Mock,
     )
     @patch(
-        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition", new=Mock
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition",
+        new=Mock,
     )
     def test_given_nads_exist_but_they_are_different_when_config_changed_then_pod_delete_is_not_called(  # noqa: E501
         self, patch_list_nads, patch_delete_pod
@@ -1090,14 +1172,18 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_pod")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
     @patch(
-        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition",
+        new=Mock,
     )
     @patch(
-        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition", new=Mock
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition",
+        new=Mock,
     )
     def test_given_nads_exist_but_are_same_when_nad_config_changed_then_pod_delete_is_not_called(
         self, patch_list_nads, patch_delete_pod
@@ -1133,10 +1219,14 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         patch_delete_pod.assert_not_called()
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition"
+    )
     def test_given_nads_exist_but_are_different_when_nad_config_changed_then_nad_create_is_called(
         self, patch_create_nad, patch_list_nads
     ):
@@ -1180,11 +1270,14 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         )
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
+    )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.patch_statefulset")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched")
     @patch(
-        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition", new=Mock
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.create_network_attachment_definition",
+        new=Mock,
     )
     def test_given_nads_not_created_when_nad_config_changed_then_patch_statefulset_is_called(
         self, patch_is_statefulset_patched, patch_patch_statefulset, patch_list_nads
@@ -1201,10 +1294,12 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
             name=harness.charm.app.name,
             network_annotations=[
                 NetworkAnnotation(
-                    name=harness.charm.annotation_1_name, interface=harness.charm.nad_1_name
+                    name=harness.charm.annotation_1_name,
+                    interface=harness.charm.nad_1_name,
                 ),
                 NetworkAnnotation(
-                    name=harness.charm.annotation_2_name, interface=harness.charm.nad_2_name
+                    name=harness.charm.annotation_2_name,
+                    interface=harness.charm.nad_2_name,
                 ),
             ],
             container_name=harness.charm.container_name,
@@ -1214,7 +1309,9 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.unpatch_statefulset")
-    def test_given_when_removed_then_statefulset_unpatched(self, patch_unpatch_statefulset):
+    def test_given_when_removed_then_statefulset_unpatched(
+        self, patch_unpatch_statefulset
+    ):
         harness = Harness(_TestCharmMultipleNAD)
         self.addCleanup(harness.cleanup)
         harness.begin()
@@ -1223,8 +1320,12 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         patch_unpatch_statefulset.assert_called()
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.network_attachment_definition_is_created")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition"
+    )
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.network_attachment_definition_is_created"
+    )
     def test_given_nad_is_created_when_remove_then_network_attachment_definitions_are_deleted(
         self, patch_is_nad_created, patch_delete_network_attachment_definition
     ):
@@ -1243,8 +1344,12 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         )
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.network_attachment_definition_is_created")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition"
+    )
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.network_attachment_definition_is_created"
+    )
     def test_given_nad_is_not_created_when_remove_then_network_attachment_definitions_are_not_deleted(  # noqa: E501
         self, patch_is_nad_created, patch_delete_network_attachment_definition
     ):
@@ -1258,7 +1363,9 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
         patch_delete_network_attachment_definition.assert_not_called()
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_network_attachment_definition"
+    )
     @patch(
         f"{MULTUS_LIBRARY_PATH}.KubernetesClient.network_attachment_definition_is_created",
         new=Mock,
@@ -1277,7 +1384,9 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.pod_is_ready")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.network_attachment_definition_is_created")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.network_attachment_definition_is_created"
+    )
     def test_given_pod_not_ready_when_is_ready_then_return_false(
         self,
         patch_nad_is_created,
@@ -1298,7 +1407,9 @@ class TestKubernetesMultusCharmLib(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.pod_is_ready")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.statefulset_is_patched")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.network_attachment_definition_is_created")
+    @patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.network_attachment_definition_is_created"
+    )
     def test_given_pod_is_ready_when_is_ready_then_return_false(
         self,
         patch_nad_is_created,

--- a/tox.ini
+++ b/tox.ini
@@ -28,24 +28,21 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff check --fix {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    codespell {[vars]lib_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
+    ruff format --check {[vars]all_path}
 
 [testenv:static]
 description = Run static analysis checks
-setenv =
-    PYTHONPATH = ""
-allowlist_externals = /usr/bin/env
 commands =
-    mypy {[vars]all_path} {posargs}
-    /usr/bin/env sh -c 'for m in $(git diff main --name-only {[vars]lib_path}); do if ! git diff main $m | grep -q "+LIBPATCH\|+LIBAPI"; then echo "You forgot to bump the version on $m!"; exit 1; fi; done'
+    pyright {[vars]all_path} {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
# Description

Replace mypy with pyright for static analysis

We also leverage this opportunity to use `ruff` for linting, just like in the other Telco owned projects.

## Rationale

- Pyright is now the default static checker in charms.
- It allows us to get rid of the type ignores comment we had for charm library imports.
- It tends to be faster though this does not matter as much. 

## Reference
- https://github.com/microsoft/pyright
- https://github.com/canonical/charmcraft/blob/main/charmcraft/templates/init-kubernetes/tox.ini.j2


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
