### PR TITLE
feat: simplify multus lib interface

### DIFF
--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -428,7 +428,7 @@ class KubernetesClient:
                 ]
             )
         )
-        container.securityContext.privileged = False
+        container.securityContext.privileged = False  # type: ignore[reportOptionalMemberAccess]
         statefulset_delta = StatefulSet(
             spec=StatefulSetSpec(
                 selector=statefulset.spec.selector,  # type: ignore[union-attr]
@@ -733,7 +733,7 @@ class KubernetesMultusCharmLib:
     def _pod_is_ready(self) -> bool:
         """Returns whether pod is ready with network annotations and capabilities."""
         return self.kubernetes.pod_is_ready(
-            pod_name=self._pod,
+            pod_name=self.pod_name,
             network_annotations=self.network_annotations,
             container_name=self.container_name,
             cap_net_admin=self.cap_net_admin,

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -94,7 +94,7 @@ import json
 import logging
 from dataclasses import asdict, dataclass
 from json.decoder import JSONDecodeError
-from typing import Callable, List, Optional, Union
+from typing import List, Optional, Union
 
 import httpx
 from lightkube.core.client import Client
@@ -115,8 +115,6 @@ from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import Pod
 from lightkube.types import PatchType
-from ops.charm import CharmBase, RemoveEvent
-from ops.framework import BoundEvent, Object
 
 # The unique Charmhub library identifier, never change it
 LIBID = "75283550e3474e7b8b5b7724d345e3c2"
@@ -126,7 +124,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 
 logger = logging.getLogger(__name__)
@@ -602,57 +600,49 @@ class KubernetesClient:
         return True
 
 
-class KubernetesMultusCharmLib(Object):
+class KubernetesMultusCharmLib:
     """Class to be instantiated by charms requiring Multus networking."""
 
     def __init__(
         self,
-        charm: CharmBase,
-        network_attachment_definitions_func: Callable[
-            [], list[NetworkAttachmentDefinition]
-        ],
-        network_annotations_func: Callable[[], list[NetworkAnnotation]],
+        network_attachment_definitions: List[NetworkAttachmentDefinition],
+        network_annotations: List[NetworkAnnotation],
+        namespace: str,
+        statefulset_name: str,
+        pod_name: str,
         container_name: str,
-        refresh_event: BoundEvent,
         cap_net_admin: bool = False,
         privileged: bool = False,
     ):
         """Constructor for the KubernetesMultusCharmLib.
 
         Args:
-            charm: Charm object
-            network_attachment_definitions_func: A callable to a function returning a list of
-              `NetworkAttachmentDefinition` to be created.
-            network_annotations_func: A callable to a function returning a list
-              of `NetworkAnnotation` to be added to the container.
+            network_attachment_definitions: list of `NetworkAttachmentDefinition` to be created.
+            network_annotations: List of `NetworkAnnotation` to be added to the container.
+            namespace: Kubernetes namespace
+            statefulset_name: Statefulset name
+            pod_name: Pod name
             container_name: Container name
             cap_net_admin: Container requires NET_ADMIN capability
             privileged: Container requires privileged security context
-            refresh_event: A BoundEvent which will be observed
-                to configure_multus (e.g. NadConfigChangedEvent).
         """
-        super().__init__(charm, "kubernetes-multus")
-        self.kubernetes = KubernetesClient(namespace=self.model.name)
-        self.network_attachment_definitions_func = network_attachment_definitions_func
-        self.network_annotations_func = network_annotations_func
+        self.namespace = namespace
+        self.statefulset_name = statefulset_name
+        self.pod_name = pod_name
+        self.kubernetes = KubernetesClient(namespace=self.namespace)
+        self.network_attachment_definitions = network_attachment_definitions
+        self.network_annotations = network_annotations
         self.container_name = container_name
         self.cap_net_admin = cap_net_admin
         self.privileged = privileged
-        # Apply custom events
-        self.framework.observe(refresh_event, self._configure_multus)
-        self.framework.observe(charm.on.remove, self._on_remove)
 
-    def _configure_multus(self, event: BoundEvent) -> None:
-        """Creates network attachment definitions and patches statefulset.
-
-        Args:
-            event: EventBase
-        """
+    def configure(self) -> None:
+        """Creates network attachment definitions and patches statefulset."""
         self._configure_network_attachment_definitions()
         if not self._statefulset_is_patched():
             self.kubernetes.patch_statefulset(
-                name=self.model.app.name,
-                network_annotations=self.network_annotations_func(),
+                name=self.statefulset_name,
+                network_annotations=self.network_annotations,
                 container_name=self.container_name,
                 cap_net_admin=self.cap_net_admin,
                 privileged=self.privileged,
@@ -667,7 +657,7 @@ class KubernetesMultusCharmLib(Object):
             return False
         if "app.juju.is/created-by" not in labels:
             return False
-        if labels["app.juju.is/created-by"] != self.model.app.name:
+        if labels["app.juju.is/created-by"] != self.statefulset_name:
             return False
         return True
 
@@ -683,9 +673,7 @@ class KubernetesMultusCharmLib(Object):
         3. Detects the NAD config changes and triggers pod restart
            if any there is any modification in existing NADs
         """
-        network_attachment_definitions_to_create = (
-            self.network_attachment_definitions_func()
-        )
+        network_attachment_definitions_to_create = self.network_attachment_definitions
         nad_config_changed = False
         for (
             existing_network_attachment_definition
@@ -725,7 +713,7 @@ class KubernetesMultusCharmLib(Object):
 
     def _network_attachment_definitions_are_created(self) -> bool:
         """Returns whether all network attachment definitions are created."""
-        for network_attachment_definition in self.network_attachment_definitions_func():
+        for network_attachment_definition in self.network_attachment_definitions:
             if not self.kubernetes.network_attachment_definition_is_created(
                 network_attachment_definition=network_attachment_definition
             ):
@@ -735,8 +723,8 @@ class KubernetesMultusCharmLib(Object):
     def _statefulset_is_patched(self) -> bool:
         """Returns whether statefuset is patched with network annotations and capabilities."""
         return self.kubernetes.statefulset_is_patched(
-            name=self.model.app.name,
-            network_annotations=self.network_annotations_func(),
+            name=self.statefulset_name,
+            network_annotations=self.network_annotations,
             container_name=self.container_name,
             cap_net_admin=self.cap_net_admin,
             privileged=self.privileged,
@@ -746,7 +734,7 @@ class KubernetesMultusCharmLib(Object):
         """Returns whether pod is ready with network annotations and capabilities."""
         return self.kubernetes.pod_is_ready(
             pod_name=self._pod,
-            network_annotations=self.network_annotations_func(),
+            network_annotations=self.network_annotations,
             container_name=self.container_name,
             cap_net_admin=self.cap_net_admin,
             privileged=self.privileged,
@@ -767,26 +755,13 @@ class KubernetesMultusCharmLib(Object):
         pod_is_ready = self._pod_is_ready()
         return nad_are_created and satefulset_is_patched and pod_is_ready
 
-    @property
-    def _pod(self) -> str:
-        """Name of the unit's pod.
-
-        Returns:
-            str: A string containing the name of the current unit's pod.
-        """
-        return "-".join(self.model.unit.name.rsplit("/", 1))
-
-    def _on_remove(self, event: RemoveEvent) -> None:
-        """Deletes network attachment definitions and removes patch.
-
-        Args:
-            event: RemoveEvent
-        """
+    def remove(self) -> None:
+        """Deletes network attachment definitions and removes patch."""
         self.kubernetes.unpatch_statefulset(
-            name=self.model.app.name,
+            name=self.statefulset_name,
             container_name=self.container_name,
         )
-        for network_attachment_definition in self.network_attachment_definitions_func():
+        for network_attachment_definition in self.network_attachment_definitions:
             if self.kubernetes.network_attachment_definition_is_created(
                 network_attachment_definition=network_attachment_definition
             ):
@@ -796,7 +771,7 @@ class KubernetesMultusCharmLib(Object):
 
     def delete_pod(self) -> None:
         """Delete the pod."""
-        self.kubernetes.delete_pod(self._pod)
+        self.kubernetes.delete_pod(self.pod_name)
 
     def multus_is_available(self) -> bool:
         """Check whether Multus is enabled leveraging existence of NAD custom resource.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 anyio==4.4.0
     # via httpx
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
@@ -14,21 +14,21 @@ h11==0.14.0
     # via httpcore
 httpcore==1.0.5
     # via httpx
-httpx==0.27.0
+httpx==0.27.2
     # via lightkube
-idna==3.7
+idna==3.8
     # via
     #   anyio
     #   httpx
-lightkube==0.15.3
+lightkube==0.15.4
     # via -r requirements.in
 lightkube-models==1.30.0.8
     # via
     #   -r requirements.in
     #   lightkube
-ops==2.15.0
+ops==2.16.1
     # via -r requirements.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   lightkube
     #   ops

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,13 +8,14 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.2.0
     # via paramiko
-cachetools==5.4.0
+cachetools==5.5.0
     # via google-auth
-certifi==2024.7.4
+certifi==2024.8.30
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
-cffi==1.17.0
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
@@ -24,25 +25,27 @@ codespell==2.3.0
     # via -r test-requirements.in
 coverage[toml]==7.6.1
     # via -r test-requirements.in
-cryptography==43.0.0
+cryptography==43.0.1
     # via paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-executing==2.0.1
+executing==2.1.0
     # via stack-data
-google-auth==2.33.0
+google-auth==2.34.0
     # via kubernetes
 hvac==2.3.0
     # via juju
-idna==3.7
-    # via requests
+idna==3.8
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.26.0
+ipython==8.27.0
     # via ipdb
 jedi==0.19.1
     # via ipython
@@ -72,7 +75,7 @@ packaging==24.1
     # via
     #   juju
     #   pytest
-paramiko==3.4.0
+paramiko==3.4.1
     # via juju
 parso==0.8.4
     # via jedi
@@ -82,7 +85,7 @@ pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.3
+protobuf==5.28.0
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
@@ -110,7 +113,7 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.376
+pyright==1.1.379
     # via -r test-requirements.in
 pytest==8.3.2
     # via
@@ -125,8 +128,9 @@ python-dateutil==2.9.0.post0
     # via kubernetes
 pytz==2024.1
     # via pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
@@ -140,7 +144,7 @@ requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruff==0.6.1
+ruff==0.6.3
     # via -r test-requirements.in
 six==1.16.0
     # via
@@ -168,6 +172,8 @@ urllib3==2.2.2
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
-    # via kubernetes
-websockets==12.0
+    # via
+    #   -c requirements.txt
+    #   kubernetes
+websockets==13.0.1
     # via juju


### PR DESCRIPTION
# Description

The current version of the k8s multus lib is quite complicated where chamrs create custom events thaththey call themselves and tell the charm lib to listen on those events. This complexitiy is unnecessary, especially as we now have a common hook approach in every Telco owned charm. Here we simplify the library. This new version:
- Does not instantiate charm base
- Does not use ops
- Only speaks with k8s 
- Provides 2 api endpoints: `configure()` and `remove()`

Fixes #55 

These PRs show the difference it makes on the CU and UPF charm:
- https://github.com/canonical/oai-ran-cu-k8s-operator/pull/20
- https://github.com/canonical/sdcore-upf-k8s-operator/pull/358

## Semantic versioning

Here we decide to stick with the same major version even if this is an API change as this lib is only used internally in telco owned projects.

## Proposal

1. Replace custom events with `configure()` and `is_configured()` calls
2. Replace `func` type attributes with list of NAD's and list of Network Annotations
3. Make the library a root class (instead of having ChildBase as a parent). Pass in everything k8s related (statefulset name, namespace, etc.)

### Current


```python
class NadConfigChangedEvent(EventBase):
    """Event triggered when an existing network attachment definition is changed."""


class UpfOperatorCharmEvents(CharmEvents):
    """Kubernetes UPF operator charm events."""

    nad_config_changed = EventSource(NadConfigChangedEvent)


class UPFOperatorCharm(CharmBase):
    """Main class to describe juju event handling for the 5G UPF operator for K8s."""

    on = UpfOperatorCharmEvents()  # type: ignore

    def __init__(self, *args):
        super().__init__(*args)

        self._kubernetes_multus = KubernetesMultusCharmLib(
            charm=self,
            container_name=self._bessd_container_name,
            cap_net_admin=True,
            network_annotations_func=self._generate_network_annotations,
            network_attachment_definitions_func=self._network_attachment_definitions_from_config,
            refresh_event=self.on.nad_config_changed,
        )
        self.framework.observe(self.on.config_changed, self._on_config_changed)

    def _on_config_changed(self, event: EventBase):
        """Handle for config changed events."""
        ...
        self.on.nad_config_changed.emit()

```

### Proposed

```python

class UPFOperatorCharm(CharmBase):
    """Main class to describe juju event handling for the 5G UPF operator for K8s."""

    def __init__(self, *args):
        super().__init__(*args)

        self._kubernetes_multus = KubernetesMultusCharmLib(
            namespace=self.model.name,
            statefulset_name=self.model.app.name,
            container_name=self._bessd_container_name,
            cap_net_admin=True,
            network_annotations=self._generate_network_annotations(),
            network_attachment_definitions=self._network_attachment_definitions_from_config(),
            refresh_event=self.on.nad_config_changed,
        )
        self.framework.observe(self.on.config_changed, self._on_config_changed)

    def _on_config_changed(self, event: EventBase):
        """Handle for config changed events."""
        ...
        if not self._kubernetes_multus.is_configured():
            self._kubernetes_multus.configure()
```


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
